### PR TITLE
feat(eslint-plugin-mark): create `no-curly-quotes` rule

### DIFF
--- a/packages/eslint-plugin-mark/src/rules/index.js
+++ b/packages/eslint-plugin-mark/src/rules/index.js
@@ -1,5 +1,7 @@
+import noCurlyQuotes from './no-curly-quotes/index.js';
 import noDoubleSpaces from './no-double-spaces/index.js';
 
 export default {
+  'no-curly-quotes': noCurlyQuotes,
   'no-double-spaces': noDoubleSpaces,
 };

--- a/packages/eslint-plugin-mark/src/rules/no-curly-quotes/index.js
+++ b/packages/eslint-plugin-mark/src/rules/no-curly-quotes/index.js
@@ -1,0 +1,3 @@
+import noCurlyQuotes from './no-curly-quotes.js';
+
+export default noCurlyQuotes;

--- a/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js
+++ b/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview Rule to disallow curly quotes(`“`, `”`, `‘` or `’`) in text.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {import("@eslint/markdown").RuleModule} RuleModule
+ * @typedef {import("mdast").Text} Text
+ */
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const leftDoubleQutationMark = '\u201C'; // `“`
+const rightDoubleQutationMark = '\u201D'; // `”`
+const leftSingleQutationMark = '\u2018'; // `‘`
+const rightSingleQutationMark = '\u2019'; // `’`
+const doubleStraightQuote = '"';
+const singleStraightQuote = "'";
+
+const newLineRegex = /\r?\n/;
+const indexOffset = 1;
+
+// --------------------------------------------------------------------------------
+// Rule Definition
+// --------------------------------------------------------------------------------
+
+/** @type {RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      recommended: true,
+      description: 'Disallow curly quotes(`“`, `”`, `‘` or `’`) in text',
+      url: 'https://github.com/lumirlumir/npm-eslint-plugin-mark',
+    },
+
+    fixable: 'code',
+
+    messages: {
+      noCurlyQuotes:
+        'Curly quotes(`“`, `”`, `‘` or `’`) are not allowed. Use straight quotes(`"` or `\'`) instead.',
+    },
+  },
+
+  create(context) {
+    return {
+      /** @param {Text} node */
+      text(node) {
+        /**
+         * - Supports both LF and CRLF line endings.
+         * - In JavaScript, `"\n"` represents a newline character and splits text accordingly.
+         *   However, in Markdown, writing `abcd\ndefg` treats `\n` as plain text (backslash + 'n'), not a newline.
+         *   Only actual line breaks in Markdown (`abcd↵defg`) are stored as `"\n"` and split properly.
+         */ // @ts-ignore -- TODO: https://github.com/eslint/markdown/issues/323
+        const lines = context.sourceCode.getText(node).split(newLineRegex);
+
+        lines.forEach((line, lineNumber) => {
+          const matches = [
+            ...line.matchAll(
+              new RegExp(
+                `[${leftDoubleQutationMark}${rightDoubleQutationMark}${leftSingleQutationMark}${rightSingleQutationMark}]`,
+                'g',
+              ),
+            ),
+          ];
+
+          if (matches.length > 0) {
+            matches.forEach(match => {
+              const curlyQuoteLength = match[0].length;
+
+              const matchIndexStart = match.index;
+              const matchIndexEnd = matchIndexStart + curlyQuoteLength;
+
+              /** Current node's start line + relative line number */
+              const locLine = node.position.start.line + lineNumber;
+              /**
+               * Consider the starting column position for the first line, otherwise calculate from the start of the line
+               * @param {number} matchIndex
+               */
+              const locColumn = matchIndex =>
+                lineNumber === 0
+                  ? node.position.start.column + matchIndex
+                  : indexOffset + matchIndex;
+
+              /** Calculating the start position of double spaces (offset-based) */
+              let positionOffset = node.position.start.offset;
+
+              for (let i = 0; i < lineNumber; i++) {
+                positionOffset += lines[i].length + 1; // Add the lengths of previous lines (`+1` for the newline character)
+              }
+
+              const rangeStart = positionOffset + matchIndexStart;
+              const rangeEnd = positionOffset + matchIndexEnd;
+
+              context.report({
+                loc: {
+                  start: {
+                    line: locLine,
+                    column: locColumn(matchIndexStart),
+                  },
+                  end: {
+                    line: locLine,
+                    column: locColumn(matchIndexEnd),
+                  },
+                },
+
+                messageId: 'noCurlyQuotes',
+
+                fix(fixer) {
+                  return fixer.replaceTextRange(
+                    [rangeStart, rangeEnd],
+                    match[0] === leftDoubleQutationMark ||
+                      match[0] === rightDoubleQutationMark
+                      ? doubleStraightQuote
+                      : singleStraightQuote,
+                  );
+                },
+              });
+            });
+          }
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js
+++ b/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js
@@ -16,10 +16,10 @@
 // Helpers
 // --------------------------------------------------------------------------------
 
-const leftDoubleQutationMark = '\u201C'; // `“`
-const rightDoubleQutationMark = '\u201D'; // `”`
-const leftSingleQutationMark = '\u2018'; // `‘`
-const rightSingleQutationMark = '\u2019'; // `’`
+const leftDoubleQuotationMark = '\u201C'; // `“`
+const rightDoubleQuotationMark = '\u201D'; // `”`
+const leftSingleQuotationMark = '\u2018'; // `‘`
+const rightSingleQuotationMark = '\u2019'; // `’`
 const doubleStraightQuote = '"';
 const singleStraightQuote = "'";
 
@@ -65,7 +65,7 @@ export default {
           const matches = [
             ...line.matchAll(
               new RegExp(
-                `[${leftDoubleQutationMark}${rightDoubleQutationMark}${leftSingleQutationMark}${rightSingleQutationMark}]`,
+                `[${leftDoubleQuotationMark}${rightDoubleQuotationMark}${leftSingleQuotationMark}${rightSingleQuotationMark}]`,
                 'g',
               ),
             ),
@@ -116,8 +116,8 @@ export default {
                 fix(fixer) {
                   return fixer.replaceTextRange(
                     [rangeStart, rangeEnd],
-                    match[0] === leftDoubleQutationMark ||
-                      match[0] === rightDoubleQutationMark
+                    match[0] === leftDoubleQuotationMark ||
+                      match[0] === rightDoubleQuotationMark
                       ? doubleStraightQuote
                       : singleStraightQuote,
                   );

--- a/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.test.js
+++ b/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.test.js
@@ -1,0 +1,230 @@
+/**
+ * @fileoverview Test for `no-curly-quotes.js`.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { test } from 'node:test';
+
+import { RuleTester } from 'eslint';
+import markdown from '@eslint/markdown';
+
+import rule from './no-curly-quotes.js';
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const noCurlyQuotes = 'noCurlyQuotes';
+
+const ruleTesterCommonmark = new RuleTester({
+  plugins: {
+    markdown,
+  },
+  language: 'markdown/commonmark',
+});
+
+const ruleTesterGfm = new RuleTester({
+  plugins: {
+    markdown,
+  },
+  language: 'markdown/gfm',
+});
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+const tests = {
+  valid: ['', ' ', '"', "'"],
+
+  invalid: [
+    {
+      name: 'Left double quotation mark in raw text',
+      code: '“',
+      output: '"',
+      errors: [
+        {
+          messageId: noCurlyQuotes,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      name: 'Right double quotation mark in raw text',
+      code: '”',
+      output: '"',
+      errors: [
+        {
+          messageId: noCurlyQuotes,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      name: 'Left single quotation mark in raw text',
+      code: '‘',
+      output: "'",
+      errors: [
+        {
+          messageId: noCurlyQuotes,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      name: 'Right single quotation mark in raw text',
+      code: '’',
+      output: "'",
+      errors: [
+        {
+          messageId: noCurlyQuotes,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      name: 'Left double quotation mark in unicode escape',
+      code: '\u201C foo',
+      output: '" foo',
+      errors: [
+        {
+          messageId: noCurlyQuotes,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      name: 'Right double quotation mark in unicode escape',
+      code: '\u201D foo',
+      output: '" foo',
+      errors: [
+        {
+          messageId: noCurlyQuotes,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      name: 'Left single quotation mark in unicode escape',
+      code: '\u2018 foo',
+      output: "' foo",
+      errors: [
+        {
+          messageId: noCurlyQuotes,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      name: 'Right single quotation mark in unicode escape',
+      code: '\u2019 foo',
+      output: "' foo",
+      errors: [
+        {
+          messageId: noCurlyQuotes,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      name: 'Mixed curly quotes in raw text',
+      code: `“foo” ‘bar’
+  “  ”
+‘  ’`,
+      output: `"foo" 'bar'
+  "  "
+'  '`,
+      errors: [
+        {
+          messageId: noCurlyQuotes,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 2,
+        },
+        {
+          messageId: noCurlyQuotes,
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 6,
+        },
+        {
+          messageId: noCurlyQuotes,
+          line: 1,
+          column: 7,
+          endLine: 1,
+          endColumn: 8,
+        },
+        {
+          messageId: noCurlyQuotes,
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 12,
+        },
+        {
+          messageId: noCurlyQuotes,
+          line: 2,
+          column: 3,
+          endLine: 2,
+          endColumn: 4,
+        },
+        {
+          messageId: noCurlyQuotes,
+          line: 2,
+          column: 6,
+          endLine: 2,
+          endColumn: 7,
+        },
+        {
+          messageId: noCurlyQuotes,
+          line: 3,
+          column: 1,
+          endLine: 3,
+          endColumn: 2,
+        },
+        {
+          messageId: noCurlyQuotes,
+          line: 3,
+          column: 4,
+          endLine: 3,
+          endColumn: 5,
+        },
+      ],
+    },
+  ],
+};
+
+test('no-curly-quotes', () => {
+  ruleTesterCommonmark.run('no-curly-quotes', rule, tests);
+  ruleTesterGfm.run('no-curly-quotes', rule, tests);
+});

--- a/website/docs/rules/no-curly-quotes.md
+++ b/website/docs/rules/no-curly-quotes.md
@@ -1,0 +1,39 @@
+# `no-curly-quotes`
+
+<kbd>Recommended ✅</kbd> <kbd>Fixable 🛠️</kbd>
+
+Disallow curly quotes(`“`, `”`, `‘` or `’`) in text
+
+## Rule Details
+
+The purpose of this rule is to allow the use of ASCII characters in the editor and optionally convert them to curly symbols during rendering, using a parser that supports this feature, such as the Typographer extension of [Goldmark](https://github.com/yuin/goldmark) or [SmartyPants](https://daringfireball.net/projects/smartypants/).
+
+Additionally, curly quotes (`“`(`\u201C`), `”`(`\u201D`), `‘`(`\u2018`) or `’`(`\u2019`)), which are often introduced by word processors like Word, Google Docs, and Pages, can cause unwanted issues in code and markup. This rule helps keep your code clean and consistent by preventing unintended curly quotes.
+
+This rule only checks for curly quotes and applies only to [`text`](https://https://github.com/syntax-tree/mdast?tab=readme-ov-file#text) node.
+
+### ❌ Incorrect
+
+Examples of **incorrect** code for this rule:
+
+```md
+“foo bar”
+‘foo bar’
+```
+
+### ✅ Correct
+
+Examples of **correct** code for this rule:
+
+```md
+"foo bar"
+'foo bar'
+```
+
+## Fix
+
+This rule fixes the curly quotes by replacing them with straight quotes.
+
+## Prior Art
+
+- [textlint-rule-no-curly-quotes](https://github.com/aborazmeh/textlint-rule-no-curly-quotes)

--- a/website/docs/rules/no-curly-quotes.md
+++ b/website/docs/rules/no-curly-quotes.md
@@ -11,6 +11,7 @@ The purpose of this rule is to allow the use of ASCII characters in the editor a
 Additionally, curly quotes (`“`(`\u201C`), `”`(`\u201D`), `‘`(`\u2018`) or `’`(`\u2019`)), which are often introduced by word processors like Word, Google Docs, and Pages, can cause unwanted issues in code and markup. This rule helps keep your code clean and consistent by preventing unintended curly quotes.
 
 This rule only checks for curly quotes and applies only to [`text`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#text) node.
+
 ### ❌ Incorrect
 
 Examples of **incorrect** code for this rule:


### PR DESCRIPTION
This pull request introduces a new ESLint rule to disallow curly quotes in text. The main changes include adding the new rule, implementing its functionality, and providing documentation and tests for it.

### Introduction of the `no-curly-quotes` rule:

* [`packages/eslint-plugin-mark/src/rules/index.js`](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R1-R5): Added the `no-curly-quotes` rule to the list of available rules.
* [`packages/eslint-plugin-mark/src/rules/no-curly-quotes/index.js`](diffhunk://#diff-772923f290eca8a618eb1ced932a7fbce81062c4eb63f1c713d7ca1d4c697874R1-R3): Created an entry point for the `no-curly-quotes` rule.

### Implementation of the `no-curly-quotes` rule:

* [`packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js`](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58R1-R132): Defined the rule to disallow curly quotes and provided the logic to detect and replace them with straight quotes.

### Testing the `no-curly-quotes` rule:

* [`packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.test.js`](diffhunk://#diff-a79b567f8645e8f78ea7976815555f9faa02f925c75631e24b869c97e4eac901R1-R230): Added tests to verify the functionality of the `no-curly-quotes` rule, covering various scenarios with valid and invalid cases.

### Documentation for the `no-curly-quotes` rule:

* [`website/docs/rules/no-curly-quotes.md`](diffhunk://#diff-0beca2e870ea11f65da46491df93afa1f8c32461bd25539315ce191ceda90262R1-R39): Documented the `no-curly-quotes` rule, including its purpose, incorrect and correct examples, and how it fixes the issues.