### PR TITLE
feat(eslint-plugin-mark): create `all` configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import bananass from 'eslint-config-bananass';
+import mark from 'eslint-plugin-mark';
 
 /** @type {import("eslint").Linter.Config[]} */
 export default [
@@ -7,4 +8,5 @@ export default [
   },
   bananass.configs.js,
   bananass.configs.ts,
+  mark.configs.all.gfm,
 ];

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,6 +3,6 @@ module.exports = {
     'npx prettier --check',
     'npx editorconfig-checker -config .editorconfig-checker.json',
   ],
-  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}': 'npx eslint',
+  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,md}': 'npx eslint',
   '*.md': ['npx markdownlint', 'npx textlint -f pretty-error'],
 };

--- a/packages/eslint-plugin-mark/src/configs/all.js
+++ b/packages/eslint-plugin-mark/src/configs/all.js
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview All rulesets from `eslint-plugin-mark`.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import markdown from '@eslint/markdown';
+import rules from '../rules/index.js';
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {import("@eslint/markdown").ParserMode} ParserMode
+ * @typedef {import("eslint").Linter.Config} LinterConfig
+ */
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * All rulesets from `eslint-plugin-mark`.
+ *
+ * @param {ParserMode} parserMode
+ * @return {LinterConfig}
+ */
+export default function all(parserMode) {
+  return {
+    name: `all/${parserMode}`,
+    files: ['**/*.md'],
+    plugins: {
+      markdown,
+      mark: { rules },
+    },
+    language: `markdown/${parserMode}`,
+    rules: {
+      'mark/no-curly-quotes': 'error',
+      'mark/no-double-spaces': 'error',
+    },
+  };
+}

--- a/packages/eslint-plugin-mark/src/configs/index.js
+++ b/packages/eslint-plugin-mark/src/configs/index.js
@@ -1,0 +1,3 @@
+import all from './all.js';
+
+export { all };

--- a/packages/eslint-plugin-mark/src/index.js
+++ b/packages/eslint-plugin-mark/src/index.js
@@ -8,6 +8,8 @@
 // --------------------------------------------------------------------------------
 
 import { createRequire } from 'node:module';
+
+import { all } from './configs/index.js';
 import rules from './rules/index.js';
 
 // --------------------------------------------------------------------------------
@@ -37,5 +39,11 @@ export default {
 
   rules,
 
-  configs: {},
+  configs: {
+    all: {
+      // @ts-ignore -- TODO: https://github.com/eslint/eslint/issues/19519
+      commonmark: all('commonmark'),
+      gfm: all('gfm'),
+    },
+  },
 };


### PR DESCRIPTION
This pull request introduces the integration of the `eslint-plugin-mark` with our existing ESLint configuration and updates the `lint-staged` configuration to include markdown files. The most important changes include importing and configuring the new plugin, adding new rules for markdown linting, and updating the `lint-staged` configuration.

### Integration of `eslint-plugin-mark`:

* [`eslint.config.mjs`](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R2): Imported `eslint-plugin-mark` and added its configuration to the ESLint setup. [[1]](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R2) [[2]](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R11)
* [`packages/eslint-plugin-mark/src/configs/all.js`](diffhunk://#diff-dcdf50541cdda584e7b5e20419349e2a8760d86d4d140d12dbd1d97b3084703fR1-R45): Created a new configuration file for all rulesets from `eslint-plugin-mark`.
* [`packages/eslint-plugin-mark/src/configs/index.js`](diffhunk://#diff-b203cdc09e7b9c5b3872303a75b6a7d4570e43a16311e2f9c3484e18b15247f9R1-R3): Exported the new configuration from the `index.js` file.
* [`packages/eslint-plugin-mark/src/index.js`](diffhunk://#diff-70f2388a14811bff072b178c7cfb31ba7a827976b08cc805892d9175b97e2277R11-R12): Integrated the new configuration into the main plugin export. [[1]](diffhunk://#diff-70f2388a14811bff072b178c7cfb31ba7a827976b08cc805892d9175b97e2277R11-R12) [[2]](diffhunk://#diff-70f2388a14811bff072b178c7cfb31ba7a827976b08cc805892d9175b97e2277L40-R48)

### Update to `lint-staged`:

* [`lint-staged.config.js`](diffhunk://#diff-29c15f0b5d8d1144bd22153c302cde16c2de092d65b122a618cbdb3023336346L6-R6): Updated the configuration to include markdown files (`*.md`) for ESLint checking.