### PR TITLE
refactor(eslint-plugin-mark): create `textHandler` for a better AST handling

### DIFF
--- a/packages/eslint-plugin-mark/src/core/ast/index.js
+++ b/packages/eslint-plugin-mark/src/core/ast/index.js
@@ -1,0 +1,3 @@
+import textHandler from './text-handler/index.js';
+
+export { textHandler };

--- a/packages/eslint-plugin-mark/src/core/ast/text-handler/index.js
+++ b/packages/eslint-plugin-mark/src/core/ast/text-handler/index.js
@@ -1,0 +1,3 @@
+import textHandler from './text-handler.js';
+
+export default textHandler;

--- a/packages/eslint-plugin-mark/src/core/ast/text-handler/text-handler.js
+++ b/packages/eslint-plugin-mark/src/core/ast/text-handler/text-handler.js
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview `TextHandler` transforms a `Text` node into a `TextExt` node by adding a `children` property.
+ */
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {import("eslint").Rule.RuleContext} RuleContext
+ * @typedef {import("../../types.d.ts").TextExt} TextExt
+ * @typedef {import("../../types.d.ts").TextLine} TextLine
+ */
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const newLineRegex = /\r?\n/;
+const indexOffset = 1; // `index` is 0-based, but `column` is 1-based.
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * `TextHandler` transforms a `Text` node into a `TextExt` node by adding a `children` property.
+ * During this process, it splits the text into multiple lines and creates `TextLine` nodes for each line.
+ * The generated `TextLine` nodes then become child elements of the `Text` node.
+ *
+ * - NOTE: This function is designed to create **SIDE EFFECTS** by modifying the original `Text` node.
+ *
+ * @param {RuleContext} context `import("eslint").Rule.RuleContext`
+ * @param {TextExt} textNode
+ */
+export default function textHandler(context, textNode) {
+  textNode.children = [];
+
+  /**
+   * - Supports both LF and CRLF line endings.
+   * - In JavaScript, `\n` represents a newline character and splits text accordingly.
+   *   However, in Markdown, writing `abcd\ndefg` treats `\n` as plain text (backslash + 'n'), not a newline.
+   *   Only actual line breaks in Markdown (`abcd↵defg`) are stored as `"\n"` and split properly.
+   */ // @ts-ignore -- TODO: https://github.com/eslint/markdown/issues/323
+  const lines = context.sourceCode.getText(textNode).split(newLineRegex);
+
+  lines.forEach((line, lineNumber) => {
+    const locLine = textNode.position.start.line + lineNumber;
+    const locColumn = lineNumber === 0 ? textNode.position.start.column : indexOffset;
+    let locOffset = textNode.position.start.offset;
+
+    for (let i = 0; i < lineNumber; i++) {
+      locOffset += lines[i].length + 1; // Add the lengths of previous lines. (`+1` for the newline character.)
+    }
+
+    textNode.children.push(
+      /** @type {TextLine} */ {
+        type: 'textLine',
+        value: line,
+        position: {
+          start: {
+            line: locLine,
+            column: locColumn,
+            offset: locOffset,
+          },
+          end: {
+            line: locLine,
+            column: locColumn + line.length,
+            offset: locOffset + line.length,
+          },
+        },
+      },
+    );
+  });
+}

--- a/packages/eslint-plugin-mark/src/core/ast/text-handler/text-handler.test.js
+++ b/packages/eslint-plugin-mark/src/core/ast/text-handler/text-handler.test.js
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview Test for `text-handler.js`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { describe, it } from 'node:test';
+import { deepStrictEqual } from 'node:assert';
+
+import { getFileName } from '../../helpers/index.js';
+
+import textHandler from './text-handler.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe(getFileName(import.meta.url), () => {
+  it('should return correct `TextExt` node: singleline', () => {
+    const text = 'foo';
+    const context = {
+      sourceCode: {
+        getText: () => text,
+      },
+    };
+    const textNode = {
+      position: {
+        start: {
+          line: 1,
+          column: 3,
+          offset: 2,
+        },
+      },
+    };
+
+    textHandler(context, textNode);
+
+    deepStrictEqual(textNode.children, [
+      {
+        type: 'textLine',
+        value: 'foo',
+        position: {
+          start: {
+            line: 1,
+            column: 3,
+            offset: 2,
+          },
+          end: {
+            line: 1,
+            column: 6,
+            offset: 5,
+          },
+        },
+      },
+    ]);
+  });
+
+  it('should return correct `TextExt` node: multiline', () => {
+    const text = `foo
+  bar
+baz`;
+    const context = {
+      sourceCode: {
+        getText: () => text,
+      },
+    };
+    const textNode = {
+      position: {
+        start: {
+          line: 1,
+          column: 1,
+          offset: 0,
+        },
+      },
+    };
+
+    textHandler(context, textNode);
+
+    deepStrictEqual(textNode.children, [
+      {
+        type: 'textLine',
+        value: 'foo',
+        position: {
+          start: {
+            line: 1,
+            column: 1,
+            offset: 0,
+          },
+          end: {
+            line: 1,
+            column: 4,
+            offset: 3,
+          },
+        },
+      },
+      {
+        type: 'textLine',
+        value: '  bar',
+        position: {
+          start: {
+            line: 2,
+            column: 1,
+            offset: 4,
+          },
+          end: {
+            line: 2,
+            column: 6,
+            offset: 9,
+          },
+        },
+      },
+      {
+        type: 'textLine',
+        value: 'baz',
+        position: {
+          start: {
+            line: 3,
+            column: 1,
+            offset: 10,
+          },
+          end: {
+            line: 3,
+            column: 4,
+            offset: 13,
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/packages/eslint-plugin-mark/src/core/types.d.ts
+++ b/packages/eslint-plugin-mark/src/core/types.d.ts
@@ -1,13 +1,12 @@
 /**
  * @fileoverview Define common types.
- * @author 루밀LuMir(lumirlumir)
  */
 
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------
 
-import type { Literal, Node, Parent, TextData, BreakData } from 'mdast'; // eslint-disable-line n/no-missing-import -- TODO: Remove this line after fixing the issue
+import type { Literal, Text } from 'mdast'; // eslint-disable-line n/no-missing-import -- TODO: Remove this line after fixing the issue
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -16,41 +15,23 @@ import type { Literal, Node, Parent, TextData, BreakData } from 'mdast'; // esli
 /**
  * Custom markdown text extension.
  */
-export interface TextExt extends Literal, Parent {
+export interface TextExt extends Text {
   /**
    * Node type of custom markdown text extension.
    */
   type: 'textExt';
   /**
-   * Data associated with the mdast text.
+   * Children of the node.
    */
-  data?: TextData | undefined;
+  children?: TextLine[] | undefined;
 }
 
 /**
- * Custom markdown line.
+ * Custom markdown text line.
  */
-export interface Line extends Literal {
+export interface TextLine extends Literal {
   /**
-   * Node type of custom markdown line.
+   * Node type of custom markdown text line.
    */
-  type: 'line';
-  /**
-   * Data associated with the mdast text.
-   */
-  data?: TextData | undefined;
-}
-
-/**
- * Custom markdown line break.
- */
-export interface LineBreak extends Node {
-  /**
-   * Node type of custom markdown line break.
-   */
-  type: 'lineBreak';
-  /**
-   * Data associated with the mdast break.
-   */
-  data?: BreakData | undefined;
+  type: 'textLine';
 }

--- a/packages/eslint-plugin-mark/src/rules/no-double-spaces/no-double-spaces.js
+++ b/packages/eslint-plugin-mark/src/rules/no-double-spaces/no-double-spaces.js
@@ -7,6 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
+import { textHandler } from '../../core/ast/index.js';
 import { getFileName } from '../../core/helpers/index.js';
 
 // --------------------------------------------------------------------------------
@@ -15,7 +16,7 @@ import { getFileName } from '../../core/helpers/index.js';
 
 /**
  * @typedef {import("@eslint/markdown").RuleModule} RuleModule
- * @typedef {import("mdast").Text} Text
+ * @typedef {import("../../core/types.d.ts").TextExt} TextExt
  */
 
 // --------------------------------------------------------------------------------
@@ -24,9 +25,7 @@ import { getFileName } from '../../core/helpers/index.js';
 
 const doubleSpacesRegex = /(?<! ) {2}(?! )/g; // Exactly two spaces. No more, no less.
 const leadingSpacesRegex = /^ */;
-const newLineRegex = /\r?\n/;
 const singleSpace = ' ';
-const indexOffset = 1; // `index` is 0-based, but `column` is 1-based.
 
 // --------------------------------------------------------------------------------
 // Rule Definition
@@ -60,64 +59,44 @@ export default {
 
   create(context) {
     return {
-      /** @param {Text} node */
+      /** @param {TextExt} node */
       text(node) {
-        /**
-         * - Supports both LF and CRLF line endings.
-         * - In JavaScript, `"\n"` represents a newline character and splits text accordingly.
-         *   However, in Markdown, writing `abcd\ndefg` treats `\n` as plain text (backslash + 'n'), not a newline.
-         *   Only actual line breaks in Markdown (`abcd↵defg`) are stored as `"\n"` and split properly.
-         */ // @ts-ignore -- TODO: https://github.com/eslint/markdown/issues/323
-        const lines = context.sourceCode.getText(node).split(newLineRegex);
+        textHandler(context, node);
 
-        lines.forEach((line, lineNumber) => {
-          const matches = [...line.trim().matchAll(doubleSpacesRegex)];
+        node.children.forEach(textLineNode => {
+          const matches = [...textLineNode.value.trim().matchAll(doubleSpacesRegex)];
 
           if (matches.length > 0) {
             matches.forEach(match => {
               const doubleSpacesLength = match[0].length;
-              const leadingSpacesLength = line.match(leadingSpacesRegex)[0].length;
+              const leadingSpacesLength =
+                textLineNode.value.match(leadingSpacesRegex)[0].length;
 
               const matchIndexStart = match.index + leadingSpacesLength;
               const matchIndexEnd = matchIndexStart + doubleSpacesLength;
 
-              /** Current node's start line + relative line number */
-              const locLine = node.position.start.line + lineNumber;
-              /**
-               * Consider the starting column position for the first line, otherwise calculate from the start of the line
-               * @param {number} matchIndex
-               */
-              const locColumn = matchIndex =>
-                lineNumber === 0
-                  ? node.position.start.column + matchIndex
-                  : indexOffset + matchIndex;
-
-              /** Calculating the start position of double spaces (offset-based) */
-              let positionOffset = node.position.start.offset;
-
-              for (let i = 0; i < lineNumber; i++) {
-                positionOffset += lines[i].length + 1; // Add the lengths of previous lines (`+1` for the newline character)
-              }
-
-              const rangeStart = positionOffset + matchIndexStart;
-              const rangeEnd = positionOffset + matchIndexEnd;
-
               context.report({
                 loc: {
                   start: {
-                    line: locLine,
-                    column: locColumn(matchIndexStart),
+                    line: textLineNode.position.start.line,
+                    column: textLineNode.position.start.column + matchIndexStart,
                   },
                   end: {
-                    line: locLine,
-                    column: locColumn(matchIndexEnd),
+                    line: textLineNode.position.start.line,
+                    column: textLineNode.position.start.column + matchIndexEnd,
                   },
                 },
 
                 messageId: 'noDoubleSpaces',
 
                 fix(fixer) {
-                  return fixer.replaceTextRange([rangeStart, rangeEnd], singleSpace);
+                  return fixer.replaceTextRange(
+                    [
+                      textLineNode.position.start.offset + matchIndexStart,
+                      textLineNode.position.start.offset + matchIndexEnd,
+                    ],
+                    singleSpace,
+                  );
                 },
               });
             });


### PR DESCRIPTION
This pull request includes several changes to the `eslint-plugin-mark` package, primarily focusing on the addition of a new `textHandler` utility and its integration into existing rules. The changes improve the handling of text nodes by splitting them into multiple lines and creating child nodes for each line. This refactoring simplifies the code and enhances maintainability.

### Integration of `textHandler` utility:

* **New Utility Addition:**
  * Added `textHandler` utility to transform a `Text` node into a `TextExt` node by splitting text into lines and creating `TextLine` child nodes. (`packages/eslint-plugin-mark/src/core/ast/text-handler/text-handler.js`)
  * Exported `textHandler` from `index.js` and `text-handler.js` files. (`packages/eslint-plugin-mark/src/core/ast/index.js`) [[1]](diffhunk://#diff-b7e92fbc37861b8886ae6d394b0411e47ca53bb20532a8d1de9bf23e756bf528R1-R3) (`packages/eslint-plugin-mark/src/core/ast/text-handler/index.js`) [[2]](diffhunk://#diff-1e470e6a321c1024e1ea996172aeac6edc42e119df9038a8e3a2b672e12d3091R1-R3)

* **Rule Updates:**
  * Integrated `textHandler` into `no-curly-quotes` rule, replacing previous line-splitting logic and updating node handling to use `TextExt` nodes. (`packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js`) [[1]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58R10) [[2]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L18-R19) [[3]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L32-L34) [[4]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L66-R70) [[5]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L93-R105)
  * Integrated `textHandler` into `no-double-spaces` rule, replacing previous line-splitting logic and updating node handling to use `TextExt` nodes. (`packages/eslint-plugin-mark/src/rules/no-double-spaces/no-double-spaces.js`) [[1]](diffhunk://#diff-45b4725c516e3cb4cdf9c2d79558ef2e4dec22be6620f5ad2590f7d2fba7c634R10) [[2]](diffhunk://#diff-45b4725c516e3cb4cdf9c2d79558ef2e4dec22be6620f5ad2590f7d2fba7c634L18-R19) [[3]](diffhunk://#diff-45b4725c516e3cb4cdf9c2d79558ef2e4dec22be6620f5ad2590f7d2fba7c634L27-L29) [[4]](diffhunk://#diff-45b4725c516e3cb4cdf9c2d79558ef2e4dec22be6620f5ad2590f7d2fba7c634L63-R99)

* **Testing:**
  * Added tests for `textHandler` to ensure correct transformation of `Text` nodes into `TextExt` nodes with proper child `TextLine` nodes. (`packages/eslint-plugin-mark/src/core/ast/text-handler/text-handler.test.js`)