### PR TITLE
chore(release): bump package versions from `v0.0.0` to `v0.1.0-canary.0` (`preminor`)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.0.0"
+  "version": "0.1.0-canary.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-plugin-mark",
-  "version": "0.0.0",
+  "version": "0.1.0-canary.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-plugin-mark",
-      "version": "0.0.0",
+      "version": "0.1.0-canary.0",
       "workspaces": [
         ".",
         "packages/*",
@@ -20,7 +20,7 @@
         "editorconfig-checker": "^6.0.0",
         "eslint": "^9.22.0",
         "eslint-config-bananass": "^0.0.6",
-        "eslint-plugin-mark": "^0.0.0",
+        "eslint-plugin-mark": "^0.1.0-canary.0",
         "husky": "^9.1.5",
         "lerna": "^8.2.1",
         "lint-staged": "^15.5.0",
@@ -20199,7 +20199,7 @@
       }
     },
     "packages/eslint-plugin-mark": {
-      "version": "0.0.0",
+      "version": "0.1.0-canary.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^6.3.0",
@@ -20222,11 +20222,11 @@
       }
     },
     "website": {
-      "version": "0.0.0",
+      "version": "0.1.0-canary.0",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
         "bananass-utils-vitepress": "^0.0.0",
-        "eslint-plugin-mark": "^0.0.0",
+        "eslint-plugin-mark": "^0.1.0-canary.0",
         "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "vitepress": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-plugin-mark",
-  "version": "0.0.0",
+  "version": "0.1.0-canary.0",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": ">=20.18.0"
@@ -42,7 +42,7 @@
     "editorconfig-checker": "^6.0.0",
     "eslint": "^9.22.0",
     "eslint-config-bananass": "^0.0.6",
-    "eslint-plugin-mark": "^0.0.0",
+    "eslint-plugin-mark": "^0.1.0-canary.0",
     "husky": "^9.1.5",
     "lerna": "^8.2.1",
     "lint-staged": "^15.5.0",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mark",
-  "version": "0.0.0",
+  "version": "0.1.0-canary.0",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "0.0.0",
+  "version": "0.1.0-canary.0",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.0",
     "bananass-utils-vitepress": "^0.0.0",
-    "eslint-plugin-mark": "^0.0.0",
+    "eslint-plugin-mark": "^0.1.0-canary.0",
     "is-interactive": "^2.0.0",
     "markdown-it-footnote": "^4.0.0",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.0`

New release of `lumirlumir/npm-eslint-plugin-mark` has arrived! :tada:

This PR bumps the package versions from `v0.0.0` to `v0.1.0-canary.0` (`preminor`).

See [Actions](https://github.com/lumirlumir/npm-eslint-plugin-mark/actions/runs/14019480719) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-plugin-mark` |
| SEMVER      | `preminor`     |
| Pre ID      | `canary`      |
| Short SHA   | eecdd5b       |
| Old Version | `v0.0.0`  |
| New Version | `v0.1.0-canary.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(eslint-plugin-mark): create `no-double-spaces` rule  by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/3
* feat(eslint-plugin-mark): create `no-curly-quotes` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/4
* feat(eslint-plugin-mark): create `all` configuration by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/5
* feat(eslint-plugin-mark): create `code-lang-shorthand` and dummy rules by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/13
### :toolbox: Chores
* chore(sync-server): update `FUNDING.yml` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/11
* chore(*): create vitepress website prototype by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/14
* chore(*): add root workspace to `package.json` and `package-lock.json` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/17
### :arrows_counterclockwise: Continuous Integrations
* ci(*): create `release.yml` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/9
### :recycle: Code Refactoring
* refactor(eslint-plugin-mark): create rule tester and make code more DRY by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/6
* refactor(eslint-plugin-mark): create `textHandler` for a better AST handling by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/7
* refactor(eslint-plugin-mark): restructure configs and update `tsconfig.json` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/12
### :arrow_up: Dependency Updates
* chore(deps-dev): bump lint-staged from 15.4.3 to 15.5.0 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/2
* chore(deps-dev): bump shx from 0.3.4 to 0.4.0 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/8
* chore(deps-dev): bump textlint-rule-allowed-uris from 1.0.8 to 1.0.9 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/10

## New Contributors
* @lumirlumir made their first contribution in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/1
* @dependabot made their first contribution in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/2

**Full Changelog**: https://github.com/lumirlumir/npm-eslint-plugin-mark/commits/v0.1.0-canary.0