### PR TITLE
refactor(eslint-plugin-mark): create `getRuleDocsUrl` helper function

### DIFF
--- a/packages/eslint-plugin-mark/src/core/constants.js
+++ b/packages/eslint-plugin-mark/src/core/constants.js
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview This file declares constants used throughout the `eslint-plugin-mark` package.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { createRequire } from 'node:module';
+
+// --------------------------------------------------------------------------------
+// Declaration
+// --------------------------------------------------------------------------------
+
+const { homepage } = createRequire(import.meta.url)('../../package.json');
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/** @type {string} */
+export const URL_HOMEPAGE = homepage;
+/** @type {string} */
+export const URL_RULES = `${URL_HOMEPAGE}/docs/rules/`;

--- a/packages/eslint-plugin-mark/src/core/helpers/get-rule-docs-url/get-rule-docs-url.js
+++ b/packages/eslint-plugin-mark/src/core/helpers/get-rule-docs-url/get-rule-docs-url.js
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Get the URL for the rule documentation based on the rule name.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { URL_RULES } from '../../constants.js';
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Get the URL for the rule documentation based on the rule name.
+ *
+ * @param {string} ruleName The name of the rule.
+ * @returns {string} The URL for the rule documentation.
+ */
+export default function getRuleDocsUrl(ruleName) {
+  return `${URL_RULES}${ruleName}`;
+}

--- a/packages/eslint-plugin-mark/src/core/helpers/get-rule-docs-url/index.js
+++ b/packages/eslint-plugin-mark/src/core/helpers/get-rule-docs-url/index.js
@@ -1,0 +1,3 @@
+import getRuleDocsUrl from './get-rule-docs-url.js';
+
+export default getRuleDocsUrl;

--- a/packages/eslint-plugin-mark/src/core/helpers/index.js
+++ b/packages/eslint-plugin-mark/src/core/helpers/index.js
@@ -1,3 +1,4 @@
 import getFileName from './get-file-name/index.js';
+import getRuleDocsUrl from './get-rule-docs-url/index.js';
 
-export { getFileName };
+export { getFileName, getRuleDocsUrl };

--- a/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js
+++ b/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js
@@ -10,7 +10,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { getFileName } from '../../core/helpers/index.js';
+import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -24,6 +24,8 @@ import { getFileName } from '../../core/helpers/index.js';
 // --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
+
+const ruleName = getFileName(import.meta.url);
 
 /** @type {Record<string, string>} */
 const langShorthandMap = Object.freeze({
@@ -109,10 +111,10 @@ export default {
 
     docs: {
       // @ts-ignore -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
-      name: getFileName(import.meta.url),
+      name: ruleName,
       recommended: true,
       description: 'Enforce the use of shorthand for code block language identifiers',
-      url: 'https://github.com/lumirlumir/npm-eslint-plugin-mark',
+      url: getRuleDocsUrl(ruleName),
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js
+++ b/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js
@@ -8,7 +8,7 @@
 // --------------------------------------------------------------------------------
 
 import { textHandler } from '../../core/ast/index.js';
-import { getFileName } from '../../core/helpers/index.js';
+import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -22,6 +22,8 @@ import { getFileName } from '../../core/helpers/index.js';
 // --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
+
+const ruleName = getFileName(import.meta.url);
 
 const leftDoubleQuotationMark = '\u201C'; // `“`
 const rightDoubleQuotationMark = '\u201D'; // `”`
@@ -41,10 +43,10 @@ export default {
 
     docs: {
       // @ts-ignore -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
-      name: getFileName(import.meta.url),
+      name: ruleName,
       recommended: true,
       description: 'Disallow curly quotes(`“`, `”`, `‘` or `’`) in text',
-      url: 'https://github.com/lumirlumir/npm-eslint-plugin-mark',
+      url: getRuleDocsUrl(ruleName),
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin-mark/src/rules/no-double-spaces/no-double-spaces.js
+++ b/packages/eslint-plugin-mark/src/rules/no-double-spaces/no-double-spaces.js
@@ -8,7 +8,7 @@
 // --------------------------------------------------------------------------------
 
 import { textHandler } from '../../core/ast/index.js';
-import { getFileName } from '../../core/helpers/index.js';
+import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -22,6 +22,8 @@ import { getFileName } from '../../core/helpers/index.js';
 // --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
+
+const ruleName = getFileName(import.meta.url);
 
 const doubleSpacesRegex = /(?<! ) {2}(?! )/g; // Exactly two spaces. No more, no less.
 const multipleSpacesRegex = /(?<! ) {2,}(?! )/g; // More than two spaces.
@@ -39,11 +41,11 @@ export default {
 
     docs: {
       // @ts-ignore -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
-      name: getFileName(import.meta.url),
+      name: ruleName,
       recommended: true,
       description:
         'Disallow double or multiple consecutive spaces in text, except for leading and trailing spaces',
-      url: 'https://github.com/lumirlumir/npm-eslint-plugin-mark',
+      url: getRuleDocsUrl(ruleName),
     },
 
     fixable: 'whitespace',


### PR DESCRIPTION
This pull request includes several changes to the `eslint-plugin-mark` package, focusing on improving the organization and functionality of rule documentation URLs. The most important changes include the addition of constants for URLs, a helper function to generate rule documentation URLs, and updates to rule files to use these new utilities.

### Constants and Helper Functions:

* [`packages/eslint-plugin-mark/src/core/constants.js`](diffhunk://#diff-3126c969fce77a7002e1a9d6449e20685869c0e7985f372eb0f6bfad8241ba26R1-R24): Added constants for the homepage URL and rules documentation URL.
* [`packages/eslint-plugin-mark/src/core/helpers/get-rule-docs-url/get-rule-docs-url.js`](diffhunk://#diff-cbaf53ba07139db6c8667add2c898b67090347128fae89fcbd642ca918e55c1dR1-R23): Created a helper function to generate rule documentation URLs based on the rule name.
* [`packages/eslint-plugin-mark/src/core/helpers/get-rule-docs-url/index.js`](diffhunk://#diff-34123db777139e01e06cecd700e0608af23e9a9acf1696a31bd17053f58b9be0R1-R3): Exported the `getRuleDocsUrl` function.

### Rule File Updates:

* [`packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js`](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bL13-R13): Updated to use `getRuleDocsUrl` for generating the rule documentation URL and refactored to store the rule name in a constant. [[1]](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bL13-R13) [[2]](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bR28-R29) [[3]](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bL112-R117)
* [`packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js`](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L11-R11): Updated to use `getRuleDocsUrl` for generating the rule documentation URL and refactored to store the rule name in a constant. [[1]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L11-R11) [[2]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58R26-R27) [[3]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L44-R49)
* [`packages/eslint-plugin-mark/src/rules/no-double-spaces/no-double-spaces.js`](diffhunk://#diff-45b4725c516e3cb4cdf9c2d79558ef2e4dec22be6620f5ad2590f7d2fba7c634L11-R11): Updated to use `getRuleDocsUrl` for generating the rule documentation URL and refactored to store the rule name in a constant. [[1]](diffhunk://#diff-45b4725c516e3cb4cdf9c2d79558ef2e4dec22be6620f5ad2590f7d2fba7c634L11-R11) [[2]](diffhunk://#diff-45b4725c516e3cb4cdf9c2d79558ef2e4dec22be6620f5ad2590f7d2fba7c634R26-R27) [[3]](diffhunk://#diff-45b4725c516e3cb4cdf9c2d79558ef2e4dec22be6620f5ad2590f7d2fba7c634L42-R48)