### PR TITLE
chore(website): add support for code block transformers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20385,12 +20385,48 @@
       "version": "0.1.0-canary.0",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
+        "@shikijs/transformers": "^3.2.1",
         "bananass-utils-vitepress": "^0.0.0",
         "eslint-plugin-mark": "^0.1.0-canary.0",
         "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "vitepress": "^1.6.3",
         "vitepress-plugin-group-icons": "^1.3.7"
+      }
+    },
+    "website/node_modules/@shikijs/core": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-FhsdxMWYu/C11sFisEp7FMGBtX/OSSbnXZDMBhGuUDBNTdsoZlMSgQv5f90rwvzWAdWIW6VobD+G3IrazxA6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "website/node_modules/@shikijs/transformers": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.2.1.tgz",
+      "integrity": "sha512-oIT40p8LOPV/6XLnUrVPeRtJtbu0Mpl+BjGFuMXw870eX9zTSQlidg7CsksFDVyUiSAOC/CH1RQm+ldZp0/6eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.2.1",
+        "@shikijs/types": "3.2.1"
+      }
+    },
+    "website/node_modules/@shikijs/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "website/node_modules/is-interactive": {

--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -17,6 +17,11 @@ import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-i
 import { codecovVitePlugin } from '@codecov/vite-plugin';
 import isInteractive from 'is-interactive';
 import rules from 'eslint-plugin-mark/rules';
+import {
+  transformerNotationWordHighlight,
+  transformerMetaWordHighlight,
+  transformerRenderWhitespace,
+} from '@shikijs/transformers';
 
 // --------------------------------------------------------------------------------
 // Constants
@@ -241,6 +246,12 @@ export default defineConfig({
       md.use(footnote);
       md.use(groupIconMdPlugin);
     },
+
+    codeTransformers: [
+      transformerNotationWordHighlight(), // https://shiki.style/packages/transformers#transformernotationwordhighlight
+      transformerMetaWordHighlight(), // https://shiki.style/packages/transformers#transformermetawordhighlight
+      transformerRenderWhitespace(), // https://shiki.style/packages/transformers#transformerrenderwhitespace
+    ],
   },
 
   vite: {

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -64,6 +64,8 @@
     #6358d4 60%
   );
   --vp-home-hero-image-filter: blur(48px);
+
+  --vp-code-line-height: 2;
 }
 
 .image-container {
@@ -87,4 +89,33 @@ code.rule-emoji {
   font-size: 0.75rem !important;
   color: var(--vp-c-text-1) !important;
   border: 1px solid var(--vp-c-text-3) !important;
+}
+
+/**
+ * Markdown Document: `transformerNotationWordHighlight` and `transformerMetaWordHighlight`
+ * -------------------------------------------------------------------------- */
+
+.highlighted-word {
+  text-decoration: wavy underline red;
+}
+
+/**
+ * Markdown Document: `transformerRenderWhitespace`
+ * -------------------------------------------------------------------------- */
+
+.language-md .vp-code .tab,
+.language-md .vp-code .space {
+  position: relative;
+}
+
+.language-md .vp-code .tab::before {
+  content: '⇥';
+  position: absolute;
+  opacity: 0.5;
+}
+
+.language-md .vp-code .space::before {
+  content: '·';
+  position: absolute;
+  opacity: 0.5;
 }

--- a/website/docs/rules/no-double-spaces.md
+++ b/website/docs/rules/no-double-spaces.md
@@ -9,7 +9,7 @@ Markdown treats double or multiple consecutive spaces within a sentence as a sin
 
 Double spaces within a sentence are usually typos and can be hard to spot. This rule helps keep your code clean and consistent.
 
-Please note that this rule only checks for **double or multiple consecutive** spaces ***within sentences***. Since **leading** and **trailing** spaces have special meanings in Markdown, this rule does not check for them. **Leading** spaces are used for creating code blocks or indentation, while **trailing** spaces are used to create line breaks.
+It only checks for **double or multiple consecutive** spaces ***within sentences***. Since **leading** and **trailing** spaces have special meanings in Markdown, this rule does not check for them. **Leading** spaces are used for creating code blocks or indentation, while **trailing** spaces are used to create line breaks.
 
 ### :x: Incorrect {#incorrect}
 
@@ -20,8 +20,7 @@ Examples of **incorrect** code for this rule:
 ::: code-group
 
 ```md [incorrect.md]
-foo  bar
-
+<!-- [!code word:  :1] -->
 foo  bar  baz
 ```
 
@@ -30,7 +29,7 @@ export default [
   // ...
   {
     rules: {
-      'mark/no-double-spaces': 'error',
+      'mark/no-double-spaces': 'error', // [!code focus]
     },
   },
   // ...
@@ -39,14 +38,19 @@ export default [
 
 :::
 
-#### With `multipleSpaces` Option
+#### With `multipleSpaces: true` Option
 
 ::: code-group
 
 ```md [incorrect.md]
-foo   bar
+<!-- [!code word:  :1] -->
+foo  bar  baz
 
-foo  bar   baz    qux
+<!-- [!code word:   :1] -->
+foo   bar   baz
+
+<!-- [!code word:    :1] -->
+foo    bar    baz    qux
 ```
 
 ```js [eslint.config.mjs]
@@ -54,9 +58,9 @@ export default [
   // ...
   {
     rules: {
-      'mark/no-double-spaces': ['error', {
-        multipleSpaces: true,
-      }],
+      'mark/no-double-spaces': ['error', { // [!code focus]
+        multipleSpaces: true, // [!code focus]
+      }], // [!code focus]
     },
   },
   // ...
@@ -74,17 +78,15 @@ Examples of **correct** code for this rule:
 ::: code-group
 
 ```md [correct.md]
-<!-- single spaces -->
 foo bar baz qux
 
-<!-- multiple (more than three) spaces -->
-foo   bar     baz
+foo   bar    baz     qux
 
-<!-- leading double space -->
   foo bar
 
-<!-- trailing double space -->
-foo bar␣␣
+foo bar  ⁡
+
+foo bar    ⁡
 ```
 
 ```js [eslint.config.mjs]
@@ -92,7 +94,7 @@ export default [
   // ...
   {
     rules: {
-      'mark/no-double-spaces': 'error',
+      'mark/no-double-spaces': 'error', // [!code focus]
     },
   },
   // ...
@@ -101,25 +103,18 @@ export default [
 
 :::
 
-#### With `multipleSpaces` Option
+#### With `multipleSpaces: true` Option
 
 ::: code-group
 
 ```md [correct.md]
-<!-- Single spaces -->
 foo bar baz qux
 
-<!-- leading double space -->
   foo bar
 
-<!-- leading multiple space -->
-    foo bar
+foo bar  ⁡
 
-<!-- trailing double space -->
-foo bar␣␣
-
-<!-- trailing multiple space -->
-foo bar␣␣␣
+foo bar    ⁡
 ```
 
 ```js [eslint.config.mjs]
@@ -127,9 +122,9 @@ export default [
   // ...
   {
     rules: {
-      'mark/no-double-spaces': ['error', {
-        multipleSpaces: true,
-      }],
+      'mark/no-double-spaces': ['error', { // [!code focus]
+        multipleSpaces: true, // [!code focus]
+      }], // [!code focus]
     },
   },
   // ...

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.0",
+    "@shikijs/transformers": "^3.2.1",
     "bananass-utils-vitepress": "^0.0.0",
     "eslint-plugin-mark": "^0.1.0-canary.0",
     "is-interactive": "^2.0.0",


### PR DESCRIPTION
This pull request includes several changes to enhance the documentation and styling of the website, as well as the addition of new code transformers. The most important changes are grouped by theme below.

### Code Transformers:

* Added imports for `transformerNotationWordHighlight`, `transformerMetaWordHighlight`, and `transformerRenderWhitespace` from `@shikijs/transformers` to `website/.vitepress/config.js`.
* Configured `codeTransformers` in `website/.vitepress/config.js` to use the new transformers.
* Updated `package.json` to include `@shikijs/transformers` as a development dependency.

### Styling:

* Added CSS rules in `website/.vitepress/theme/style.css` to support the new transformers, including styles for highlighted words and whitespace rendering.

### Documentation:

* Improved the documentation in `website/docs/rules/no-double-spaces.md` by clarifying the rule descriptions and adding code annotations for better readability. [[1]](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL12-R12) [[2]](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL23-R23) [[3]](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL33-R32) [[4]](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL42-R52) [[5]](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL57-R63) [[6]](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL77-R97) [[7]](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL104-R127)