### PR TITLE
feat(eslint-plugin-mark): add options to `no-curly-quotes`

### DIFF
--- a/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js
+++ b/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js
@@ -109,10 +109,13 @@ export default {
           leftSingleQuotationMarkOption ? leftSingleQuotationMark : '',
           rightSingleQuotationMarkOption ? rightSingleQuotationMark : '',
         ].join('');
-        const regex = new RegExp(`[${regexString}]`, 'g');
+
+        if (!regexString) return;
 
         node.children.forEach(textLineNode => {
-          const matches = [...textLineNode.value.matchAll(regex)];
+          const matches = [
+            ...textLineNode.value.matchAll(new RegExp(`[${regexString}]`, 'g')),
+          ];
 
           if (matches.length > 0) {
             matches.forEach(match => {

--- a/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js
+++ b/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js
@@ -29,8 +29,8 @@ const leftDoubleQuotationMark = '\u201C'; // `“`
 const rightDoubleQuotationMark = '\u201D'; // `”`
 const leftSingleQuotationMark = '\u2018'; // `‘`
 const rightSingleQuotationMark = '\u2019'; // `’`
-const doubleStraightQuote = '"';
-const singleStraightQuote = "'";
+const doubleQuotationMark = '"';
+const singleQuotationMark = "'";
 
 // --------------------------------------------------------------------------------
 // Rule Definition
@@ -51,6 +51,36 @@ export default {
 
     fixable: 'code',
 
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          leftDoubleQuotationMark: {
+            type: 'boolean',
+          },
+          rightDoubleQuotationMark: {
+            type: 'boolean',
+          },
+          leftSingleQuotationMark: {
+            type: 'boolean',
+          },
+          rightSingleQuotationMark: {
+            type: 'boolean',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+
+    defaultOptions: [
+      {
+        leftDoubleQuotationMark: true,
+        rightDoubleQuotationMark: true,
+        leftSingleQuotationMark: true,
+        rightSingleQuotationMark: true,
+      },
+    ],
+
     messages: {
       noCurlyQuotes:
         'Curly quotes(`“`, `”`, `‘` or `’`) are not allowed. Use straight quotes(`"` or `\'`) instead.',
@@ -67,15 +97,22 @@ export default {
       text(node) {
         textHandler(context, node);
 
+        const {
+          leftDoubleQuotationMark: leftDoubleQuotationMarkOption,
+          rightDoubleQuotationMark: rightDoubleQuotationMarkOption,
+          leftSingleQuotationMark: leftSingleQuotationMarkOption,
+          rightSingleQuotationMark: rightSingleQuotationMarkOption,
+        } = context.options[0];
+        const regexString = [
+          leftDoubleQuotationMarkOption ? leftDoubleQuotationMark : '',
+          rightDoubleQuotationMarkOption ? rightDoubleQuotationMark : '',
+          leftSingleQuotationMarkOption ? leftSingleQuotationMark : '',
+          rightSingleQuotationMarkOption ? rightSingleQuotationMark : '',
+        ].join('');
+        const regex = new RegExp(`[${regexString}]`, 'g');
+
         node.children.forEach(textLineNode => {
-          const matches = [
-            ...textLineNode.value.matchAll(
-              new RegExp(
-                `[${leftDoubleQuotationMark}${rightDoubleQuotationMark}${leftSingleQuotationMark}${rightSingleQuotationMark}]`,
-                'g',
-              ),
-            ),
-          ];
+          const matches = [...textLineNode.value.matchAll(regex)];
 
           if (matches.length > 0) {
             matches.forEach(match => {
@@ -105,8 +142,8 @@ export default {
                       textLineNode.position.start.offset + matchIndexEnd,
                     ],
                     [leftDoubleQuotationMark, rightDoubleQuotationMark].includes(match[0])
-                      ? doubleStraightQuote
-                      : singleStraightQuote,
+                      ? doubleQuotationMark
+                      : singleQuotationMark,
                   );
                 },
               });

--- a/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.test.js
+++ b/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.test.js
@@ -24,7 +24,75 @@ const noCurlyQuotes = 'noCurlyQuotes';
 // --------------------------------------------------------------------------------
 
 const tests = {
-  valid: ['', ' ', '"', "'"],
+  valid: [
+    // Default
+    '',
+    ' ',
+    '"',
+    "'",
+
+    // With options
+    {
+      name: 'Zero width string with all options disabled',
+      code: '',
+      options: [
+        {
+          leftDoubleQuotationMark: false,
+          rightDoubleQuotationMark: false,
+          leftSingleQuotationMark: false,
+          rightSingleQuotationMark: false,
+        },
+      ],
+    },
+    {
+      name: 'Empty string with all options disabled',
+      code: ' ',
+      options: [
+        {
+          leftDoubleQuotationMark: false,
+          rightDoubleQuotationMark: false,
+          leftSingleQuotationMark: false,
+          rightSingleQuotationMark: false,
+        },
+      ],
+    },
+    {
+      name: 'Disable left double quotation mark',
+      code: '“',
+      options: [
+        {
+          leftDoubleQuotationMark: false,
+        },
+      ],
+    },
+    {
+      name: 'Disable right double quotation mark',
+      code: '”',
+      options: [
+        {
+          rightDoubleQuotationMark: false,
+        },
+      ],
+    },
+    {
+      name: 'Disable left single quotation mark',
+      code: '‘',
+      options: [
+        {
+          leftSingleQuotationMark: false,
+        },
+      ],
+    },
+    {
+      name: 'Disable right single quotation mark',
+      code: '’',
+      options: [
+        {
+          rightSingleQuotationMark: false,
+        },
+      ],
+    },
+  ],
 
   invalid: [
     {

--- a/website/docs/rules/no-curly-quotes.md
+++ b/website/docs/rules/no-curly-quotes.md
@@ -7,31 +7,110 @@
 
 The purpose of this rule is to allow the use of ASCII characters in the editor and optionally convert them to curly symbols during rendering, using a parser that supports this feature, such as the Typographer extension of [Goldmark](https://github.com/yuin/goldmark) or [SmartyPants](https://daringfireball.net/projects/smartypants/).
 
-Additionally, curly quotes (`“`(`\u201C`), `”`(`\u201D`), `‘`(`\u2018`) or `’`(`\u2019`)), which are often introduced by word processors like Word, Google Docs, and Pages, can cause unwanted issues in code and markup. This rule helps keep your code clean and consistent by preventing unintended curly quotes.
+In addition, curly quotes (`“` `\u201C`, `”` `\u201D`, `‘` `\u2018` or `’` `\u2019`), which are often introduced by word processors like Word, Google Docs, and Pages, can cause unwanted issues in code and markup. By applying this rule, you can prevent unintended curly quotes and keep your code clean and consistent.
 
-This rule only checks for curly quotes and applies only to [`text`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#text) node.
-
-### ❌ Incorrect
+### :x: Incorrect {#incorrect}
 
 Examples of **incorrect** code for this rule:
 
-```md
+#### Default
+
+::: code-group
+
+```md [incorrect.md] /“/ /”/ /‘/ /’/
 “foo bar”
+
 ‘foo bar’
+
+“foo ‘bar baz’ qux”
 ```
 
-### ✅ Correct
+```js [eslint.config.mjs] {5}
+export default [
+  // ...
+  {
+    rules: {
+      'mark/no-curly-quotes': 'error', // [!code focus]
+    },
+  },
+  // ...
+];
+```
+
+:::
+
+### :white_check_mark: Correct {#correct}
 
 Examples of **correct** code for this rule:
 
-```md
+#### Default
+
+::: code-group
+
+```md [correct.md]
 "foo bar"
+
 'foo bar'
+
+"foo 'bar baz' qux"
 ```
+
+```js [eslint.config.mjs] {5}
+export default [
+  // ...
+  {
+    rules: {
+      'mark/no-curly-quotes': 'error', // [!code focus]
+    },
+  },
+  // ...
+];
+```
+
+:::
+
+## Options
+
+```js
+'mark/no-curly-quotes': ['error', {
+  leftDoubleQuotationMark: true,
+  rightDoubleQuotationMark: true,
+  leftSingleQuotationMark: true,
+  rightSingleQuotationMark: true,
+}]
+```
+
+### `leftDoubleQuotationMark`
+
+> Default: `true`
+
+When `leftDoubleQuotationMark` is set to `false`, this rule will not check for the left double quotation mark (`“`).
+
+### `rightDoubleQuotationMark`
+
+> Default: `true`
+
+When `rightDoubleQuotationMark` is set to `false`, this rule will not check for the right double quotation mark (`”`).
+
+### `leftSingleQuotationMark`
+
+> Default: `true`
+
+When `leftSingleQuotationMark` is set to `false`, this rule will not check for the left single quotation mark (`‘`).
+
+### `rightSingleQuotationMark`
+
+> Default: `true`
+
+When `rightSingleQuotationMark` is set to `false`, this rule will not check for the right single quotation mark (`’`).
 
 ## Fix
 
 This rule fixes the curly quotes by replacing them with straight quotes.
+
+## AST
+
+This rule applies only to the [`Text`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#text) node.
 
 ## Prior Art
 

--- a/website/docs/rules/no-double-spaces.md
+++ b/website/docs/rules/no-double-spaces.md
@@ -24,7 +24,7 @@ Examples of **incorrect** code for this rule:
 foo  bar  baz
 ```
 
-```js [eslint.config.mjs]
+```js [eslint.config.mjs] {5}
 export default [
   // ...
   {
@@ -53,7 +53,7 @@ foo   bar   baz
 foo    bar    baz    qux
 ```
 
-```js [eslint.config.mjs]
+```js [eslint.config.mjs] {5-7}
 export default [
   // ...
   {
@@ -89,7 +89,7 @@ foo bar  ⁡
 foo bar    ⁡
 ```
 
-```js [eslint.config.mjs]
+```js [eslint.config.mjs] {5}
 export default [
   // ...
   {
@@ -117,7 +117,7 @@ foo bar  ⁡
 foo bar    ⁡
 ```
 
-```js [eslint.config.mjs]
+```js [eslint.config.mjs] {5-7}
 export default [
   // ...
   {


### PR DESCRIPTION
This pull request introduces several enhancements to the `no-curly-quotes` rule in the `eslint-plugin-mark` package. The most significant changes include renaming constants for clarity, adding configuration options for specific quotation marks, updating the rule logic to use these options, and improving the documentation and tests to reflect these updates.

### Enhancements to the `no-curly-quotes` rule:

* [`packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js`](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L32-R33): Renamed constants `doubleStraightQuote` and `singleStraightQuote` to `doubleQuotationMark` and `singleQuotationMark` for clarity. Added schema and default options to allow configuration of specific quotation marks. Updated the rule logic to use these options for more granular control. [[1]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L32-R33) [[2]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58R54-R83) [[3]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58R100-R115) [[4]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L108-R146)

### Updates to tests:

* [`packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.test.js`](diffhunk://#diff-a79b567f8645e8f78ea7976815555f9faa02f925c75631e24b869c97e4eac901L27-R95): Added new test cases to cover different configurations of the `no-curly-quotes` rule, ensuring all options are properly tested.

### Documentation improvements:

* [`website/docs/rules/no-curly-quotes.md`](diffhunk://#diff-0beca2e870ea11f65da46491df93afa1f8c32461bd25539315ce191ceda90262L10-R114): Enhanced the documentation to include detailed descriptions of the new options, updated examples, and improved formatting for clarity.

### Minor documentation updates:

* [`website/docs/rules/no-double-spaces.md`](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL27-R27): Added line highlighting to code examples for better readability. [[1]](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL27-R27) [[2]](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL56-R56) [[3]](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL92-R92) [[4]](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL120-R120)