### PR TITLE
docs(website): update documentation for `code-lang-shorthand`

### DIFF
--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -12,6 +12,10 @@
       "types": "./build/rules/index.d.ts",
       "default": "./src/rules/index.js"
     },
+    "./constants": {
+      "types": "./build/core/constants.d.ts",
+      "default": "./src/core/constants.js"
+    },
     "./package.json": "./package.json"
   },
   "typesVersions": {
@@ -24,6 +28,9 @@
       ],
       "./rules": [
         "./build/rules/index.d.ts"
+      ],
+      "./constants": [
+        "./build/core/constants.d.ts"
       ]
     }
   },

--- a/packages/eslint-plugin-mark/src/core/constants.js
+++ b/packages/eslint-plugin-mark/src/core/constants.js
@@ -21,4 +21,4 @@ const { homepage } = createRequire(import.meta.url)('../../package.json');
 /** @type {string} */
 export const URL_HOMEPAGE = homepage;
 /** @type {string} */
-export const URL_RULES = `${URL_HOMEPAGE}/docs/rules/`;
+export const URL_RULE_DOCS = `${URL_HOMEPAGE}/docs/rules/`;

--- a/packages/eslint-plugin-mark/src/core/constants.js
+++ b/packages/eslint-plugin-mark/src/core/constants.js
@@ -12,13 +12,28 @@ import { createRequire } from 'node:module';
 // Declaration
 // --------------------------------------------------------------------------------
 
-const { homepage } = createRequire(import.meta.url)('../../package.json');
+const { description, homepage, name } = createRequire(import.meta.url)(
+  '../../package.json',
+);
 
 // --------------------------------------------------------------------------------
 // Export
 // --------------------------------------------------------------------------------
 
 /** @type {string} */
+export const PKG_DESCRIPTION = description;
+/** @type {string} */
+export const PKG_NAME = name;
+/** @type {string} */
+export const PKG_AUTHOR = '루밀LuMir';
+
+/** @type {string} */
 export const URL_HOMEPAGE = homepage;
 /** @type {string} */
+export const URL_GITHUB = `https://github.com/lumirlumir/npm-${PKG_NAME}`;
+/** @type {string} */
+export const URL_NPM = 'https://www.npmjs.com';
+/** @type {string} */
 export const URL_RULE_DOCS = `${URL_HOMEPAGE}/docs/rules/`;
+/** @type {string} */
+export const URL_RULE_SRC = `${URL_GITHUB}/tree/main/packages/${PKG_NAME}/src/rules`;

--- a/packages/eslint-plugin-mark/src/core/helpers/get-rule-docs-url/get-rule-docs-url.js
+++ b/packages/eslint-plugin-mark/src/core/helpers/get-rule-docs-url/get-rule-docs-url.js
@@ -6,7 +6,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { URL_RULES } from '../../constants.js';
+import { URL_RULE_DOCS } from '../../constants.js';
 
 // --------------------------------------------------------------------------------
 // Export
@@ -19,5 +19,5 @@ import { URL_RULES } from '../../constants.js';
  * @returns {string} The URL for the rule documentation.
  */
 export default function getRuleDocsUrl(ruleName) {
-  return `${URL_RULES}${ruleName}`;
+  return `${URL_RULE_DOCS}${ruleName}`;
 }

--- a/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js
+++ b/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js
@@ -112,7 +112,7 @@ export default {
     docs: {
       // @ts-ignore -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
       name: ruleName,
-      recommended: true,
+      recommended: false,
       description: 'Enforce the use of shorthand for code block language identifiers',
       url: getRuleDocsUrl(ruleName),
     },

--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -277,12 +277,19 @@ export default defineConfig({
       pageData.frontmatter.title = ruleName;
       pageData.frontmatter.rule = `
 
+<h1>
+  <code>${ruleName}</code>
+</h1>
 <p>
   ${(rule.meta.docs.recommended ?? false) ? '<code class="rule-emoji">✅ Recommended</code>' : ''}
   ${(rule.meta.fixable ?? false) ? '<code class="rule-emoji">🔧 Fixable</code>' : ''}
   ${(rule.meta.docs.suggestion ?? false) ? '<code class="rule-emoji">💡 Suggestion</code>' : ''}
   ${(rule.meta.dialects.includes('commonmark') ?? false) ? '<code class="rule-emoji">⭐ CommonMark</code>' : ''}
   ${(rule.meta.dialects.includes('gfm') ?? false) ? '<code class="rule-emoji">🌟 GFM</code>' : ''}
+</p>
+<p>
+  <code class="rule-emoji">🔗 Rule Source</code>
+  <code class="rule-emoji">🔗 Test Source</code>
 </p>
 <p>
   ${(rule.meta.docs.description ?? '')

--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -1,6 +1,5 @@
 /**
  * @fileoverview Vitepress site configuration.
- *
  * @see https://vitepress.dev/reference/site-config#site-config
  */
 
@@ -11,12 +10,22 @@
 import { parse } from 'node:path';
 
 import { generateGoogleAnalyticsScript } from 'bananass-utils-vitepress/head';
+import rules from 'eslint-plugin-mark/rules';
+import {
+  PKG_NAME,
+  PKG_DESCRIPTION,
+  PKG_AUTHOR,
+  URL_HOMEPAGE,
+  URL_GITHUB,
+  URL_NPM,
+  URL_RULE_SRC,
+} from 'eslint-plugin-mark/constants';
+
 import footnote from 'markdown-it-footnote';
 import { defineConfig } from 'vitepress';
 import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons';
 import { codecovVitePlugin } from '@codecov/vite-plugin';
 import isInteractive from 'is-interactive';
-import rules from 'eslint-plugin-mark/rules';
 import {
   transformerNotationWordHighlight,
   transformerMetaWordHighlight,
@@ -27,12 +36,6 @@ import {
 // Constants
 // --------------------------------------------------------------------------------
 
-const TITLE = 'eslint-plugin-mark';
-const DESCRIPTION = 'Lint your Markdown with ESLint.🛠️';
-const AUTHOR = '루밀LuMir';
-const SITE_URL = 'https://eslint-plugin-mark.lumir.page';
-const GITHUB_URL = 'https://github.com/lumirlumir/npm-eslint-plugin-mark';
-const NPM_URL = 'https://www.npmjs.com';
 const GOOGLE_GA_ID = 'G-9KLYX5PTLT';
 
 // --------------------------------------------------------------------------------
@@ -41,16 +44,16 @@ const GOOGLE_GA_ID = 'G-9KLYX5PTLT';
 
 export default defineConfig({
   /* Site Metadata */
-  title: TITLE,
-  description: DESCRIPTION,
+  title: PKG_NAME,
+  description: PKG_DESCRIPTION,
   head: [
     // Basic
     ['link', { rel: 'icon', href: '/logo.svg', type: 'image/svg+xml' }],
     ['link', { rel: 'icon', href: '/logo-small.png', type: 'image/png' }],
     ['link', { rel: 'icon', href: '/favicon.ico', type: 'image/x-icon' }],
-    ['meta', { name: 'title', content: TITLE }],
+    ['meta', { name: 'title', content: PKG_NAME }],
     ['meta', { name: 'theme-color', content: '#a0a0f5' }],
-    ['meta', { name: 'author', content: AUTHOR }],
+    ['meta', { name: 'author', content: PKG_AUTHOR }],
     [
       'meta',
       {
@@ -61,21 +64,21 @@ export default defineConfig({
 
     // Open Graph
     ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:url', content: SITE_URL }],
-    ['meta', { property: 'og:title', content: TITLE }],
-    ['meta', { property: 'og:description', content: DESCRIPTION }],
-    ['meta', { property: 'og:image', content: `${SITE_URL}/logo-og.png` }],
+    ['meta', { property: 'og:url', content: URL_HOMEPAGE }],
+    ['meta', { property: 'og:title', content: PKG_NAME }],
+    ['meta', { property: 'og:description', content: PKG_DESCRIPTION }],
+    ['meta', { property: 'og:image', content: `${URL_HOMEPAGE}/logo-og.png` }],
     ['meta', { property: 'og:image:width', content: '1280' }],
     ['meta', { property: 'og:image:height', content: '640' }],
-    ['meta', { property: 'og:site_name', content: TITLE }],
-    ['meta', { property: 'og:article:author', content: AUTHOR }],
+    ['meta', { property: 'og:site_name', content: PKG_NAME }],
+    ['meta', { property: 'og:article:author', content: PKG_AUTHOR }],
 
     // Twitter
-    ['meta', { name: 'twitter:url', content: SITE_URL }],
-    ['meta', { name: 'twitter:title', content: TITLE }],
-    ['meta', { name: 'twitter:description', content: DESCRIPTION }],
-    ['meta', { name: 'twitter:image', content: `${SITE_URL}/logo-og.png` }],
-    ['meta', { name: 'twitter:creator', content: AUTHOR }],
+    ['meta', { name: 'twitter:url', content: URL_HOMEPAGE }],
+    ['meta', { name: 'twitter:title', content: PKG_NAME }],
+    ['meta', { name: 'twitter:description', content: PKG_DESCRIPTION }],
+    ['meta', { name: 'twitter:image', content: `${URL_HOMEPAGE}/logo-og.png` }],
+    ['meta', { name: 'twitter:creator', content: PKG_AUTHOR }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
 
     // Google Analytics
@@ -95,7 +98,7 @@ export default defineConfig({
 
   /* Sitemap */
   sitemap: {
-    hostname: SITE_URL,
+    hostname: URL_HOMEPAGE,
   },
 
   /* Theme Configuration */
@@ -216,18 +219,18 @@ export default defineConfig({
     socialLinks: [
       {
         icon: 'npm',
-        link: `${NPM_URL}/package/eslint-plugin-mark`,
+        link: `${URL_NPM}/package/eslint-plugin-mark`,
         ariaLabel: 'npm package link for eslint-plugin-mark',
       },
       {
         icon: 'github',
-        link: GITHUB_URL,
+        link: URL_GITHUB,
         ariaLabel: 'GitHub repository link for eslint-plugin-mark',
       },
     ],
 
     editLink: {
-      pattern: `${GITHUB_URL}/edit/main/website/:path`,
+      pattern: `${URL_GITHUB}/edit/main/website/:path`,
       text: 'Edit this page on GitHub',
     },
 
@@ -237,7 +240,7 @@ export default defineConfig({
 
     footer: {
       message: 'Released under the MIT License.',
-      copyright: `Copyright © 2024-${new Date().getFullYear()} <a href="https://github.com/lumirlumir">${AUTHOR}(lumirlumir)</a>`,
+      copyright: `Copyright © 2024-${new Date().getFullYear()} <a href="https://github.com/lumirlumir">${PKG_AUTHOR}(lumirlumir)</a>`,
     },
   },
 
@@ -288,8 +291,8 @@ export default defineConfig({
   ${(rule.meta.dialects.includes('gfm') ?? false) ? '<code class="rule-emoji">🌟 GFM</code>' : ''}
 </p>
 <p>
-  <code class="rule-emoji">🔗 Rule Source</code>
-  <code class="rule-emoji">🔗 Test Source</code>
+  <code class="rule-emoji">🔗 <a target="_blank" href="${URL_RULE_SRC}/${ruleName}/${ruleName}.js">Rule Source</a></code>
+  <code class="rule-emoji">🔗 <a target="_blank" href="${URL_RULE_SRC}/${ruleName}/${ruleName}.test.js">Test Source</a></code>
 </p>
 <p>
   ${(rule.meta.docs.description ?? '')

--- a/website/docs/rules/code-lang-shorthand.md
+++ b/website/docs/rules/code-lang-shorthand.md
@@ -3,7 +3,142 @@
 
 ## Rule Details
 
-case insensitive
+The purpose of this rule is to enforce the use of shorthand language identifiers in code blocks. Some may want to use abbreviated language identifiers to keep the code blocks concise and consistent.
+
+Using shorthand language identifiers offers several advantages: they improve readability by simplifying code, optimize file size, ensure consistency across code blocks, and make it easier for tools and automation systems to process language identifiers efficiently.
+
+Note that the code block language identifiers are **case-insensitive**, meaning `JavaScript`, `javascript`, and `JAVASCRIPT` are all treated as the same language identifier.
+
+You can see the full list of [language identifiers shorthand mapping](https://github.com/lumirlumir/npm-eslint-plugin-mark/blob/main/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js#L31-L101) in the source code.
+
+### :x: Incorrect {#incorrect}
+
+Examples of **incorrect** code for this rule:
+
+#### Default
+
+::: code-group
+
+````md [incorrect.md] /javascript/ /typescript/ /markdown/
+```javascript
+console.log('Hello, world!');
+```
+
+```typescript
+console.log('Hello, world!');
+```
+
+```markdown
+Hello, world!
+```
+````
+
+```js [eslint.config.mjs] {5}
+export default [
+  // ...
+  {
+    rules: {
+      'mark/code-lang-shorthand': 'error', // [!code focus]
+    },
+  },
+  // ...
+];
+```
+
+:::
+
+#### With `override: { example: 'ex' }` Option
+
+::: code-group
+
+````md [incorrect.md]
+<!-- [!code word:example:1] -->
+```example
+Welcome to the example language!
+```
+````
+
+```js [eslint.config.mjs] {5-7}
+export default [
+  // ...
+  {
+    rules: {
+      'mark/code-lang-shorthand': ['error', { // [!code focus]
+        override: { example: 'ex' }, // [!code focus]
+      }], // [!code focus]
+    },
+  },
+  // ...
+];
+```
+
+:::
+
+### :white_check_mark: Correct {#correct}
+
+Examples of **correct** code for this rule:
+
+#### Default
+
+::: code-group
+
+````md [correct.md]
+```js
+console.log('Hello, world!');
+```
+
+```ts
+console.log('Hello, world!');
+```
+
+```md
+Hello, world!
+```
+````
+
+```js [eslint.config.mjs] {5}
+export default [
+  // ...
+  {
+    rules: {
+      'mark/code-lang-shorthand': 'error', // [!code focus]
+    },
+  },
+  // ...
+];
+```
+
+:::
+
+#### With `ignores: ['javascript', 'typescript']` Option
+
+::: code-group
+
+````md [correct.md]
+```javascript
+console.log('Hello, world!');
+```
+
+```typescript
+console.log('Hello, world!');
+```
+````
+
+```js [eslint.config.mjs] {5-7}
+export default [
+  // ...
+  {
+    rules: {
+      'mark/code-lang-shorthand': ['error', { // [!code focus]
+        ignores: ['javascript', 'typescript'], // [!code focus]
+      }], // [!code focus]
+    },
+  },
+  // ...
+];
+```
+
+:::
 
 ## Options
 
@@ -18,7 +153,7 @@ case insensitive
 
 > Default: `[]`
 
-An array of code block language identifiers to ignore. Each value should be a lowercase, unabridged language identifier.
+An array of code block language identifiers to ignore. Each value should be a **lowercase**, unabridged language identifier.
 
 For example, to ignore the `javascript` and `typescript` language identifiers:
 

--- a/website/docs/rules/code-lang-shorthand.md
+++ b/website/docs/rules/code-lang-shorthand.md
@@ -1,8 +1,67 @@
-# `{{ $frontmatter.title }}`
-
-<!-- markdownlint-disable-next-line no-inline-html -->
-<div v-html="$frontmatter.rule"></div>
+<!-- markdownlint-disable-next-line no-inline-html first-line-h1 -->
+<header v-html="$frontmatter.rule"></header>
 
 ## Rule Details
 
 case insensitive
+
+## Options
+
+```js
+'mark/code-lang-shorthand': ['error', {
+  ignores: [],
+  override: {},
+}]
+```
+
+### `ignores`
+
+> Default: `[]`
+
+An array of code block language identifiers to ignore. Each value should be a lowercase, unabridged language identifier.
+
+For example, to ignore the `javascript` and `typescript` language identifiers:
+
+```js
+'mark/code-lang-shorthand': ['error', {
+  ignores: ['javascript', 'typescript'],
+}]
+```
+
+### `override`
+
+> Default: `{}`
+
+An object where the key is the unabridged language identifier and the value is the abbreviated form.
+
+#### Adding a new abbreviation
+
+For example, to shorten the `example` language identifier to `ex`:
+
+```js
+'mark/code-lang-shorthand': ['error', {
+  override: {
+    example: 'ex',
+  },
+}]
+```
+
+#### Overriding an existing abbreviation
+
+For example, to change the default abbreviation for `javascript` to `mjs`:
+
+```js
+'mark/code-lang-shorthand': ['error', {
+  override: {
+    javascript: 'mjs',
+  },
+}]
+```
+
+## Fix
+
+This rule converts unabridged code block language identifiers into their abbreviated forms.
+
+## AST
+
+This rule applies only to the [`Code`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#code) node.

--- a/website/docs/rules/no-curly-quotes.md
+++ b/website/docs/rules/no-curly-quotes.md
@@ -1,7 +1,5 @@
-# `{{ $frontmatter.title }}`
-
-<!-- markdownlint-disable-next-line no-inline-html -->
-<div v-html="$frontmatter.rule"></div>
+<!-- markdownlint-disable-next-line no-inline-html first-line-h1 -->
+<header v-html="$frontmatter.rule"></header>
 
 ## Rule Details
 

--- a/website/docs/rules/no-double-spaces.md
+++ b/website/docs/rules/no-double-spaces.md
@@ -1,7 +1,5 @@
-# `{{ $frontmatter.title }}`
-
-<!-- markdownlint-disable-next-line no-inline-html -->
-<div v-html="$frontmatter.rule"></div>
+<!-- markdownlint-disable-next-line no-inline-html first-line-h1 -->
+<header v-html="$frontmatter.rule"></header>
 
 ## Rule Details
 


### PR DESCRIPTION
This pull request includes various updates to the `eslint-plugin-mark` package and its documentation, focusing on adding new constants, updating configurations, and enhancing rule documentation. The most important changes include adding new constants to the package, updating the website configuration to use these constants, and improving rule documentation formatting.

### Package Updates:

* [`packages/eslint-plugin-mark/package.json`](diffhunk://#diff-9b9400561d26b4f60200e53b8fbb54b0ef18955f8348a54f396c6ac386667a0dR15-R18): Added new constants for `types` and `default` paths in the exports section. [[1]](diffhunk://#diff-9b9400561d26b4f60200e53b8fbb54b0ef18955f8348a54f396c6ac386667a0dR15-R18) [[2]](diffhunk://#diff-9b9400561d26b4f60200e53b8fbb54b0ef18955f8348a54f396c6ac386667a0dR31-R33)
* [`packages/eslint-plugin-mark/src/core/constants.js`](diffhunk://#diff-3126c969fce77a7002e1a9d6449e20685869c0e7985f372eb0f6bfad8241ba26L15-R39): Added new constants `PKG_DESCRIPTION`, `PKG_NAME`, and `PKG_AUTHOR` and updated existing URL constants to use these new constants.

### Configuration Updates:

* [`website/.vitepress/config.js`](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1L3): Updated the site configuration to use the new constants `PKG_NAME`, `PKG_DESCRIPTION`, `PKG_AUTHOR`, `URL_HOMEPAGE`, `URL_GITHUB`, `URL_NPM`, and `URL_RULE_SRC` for metadata and links. [[1]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1L3) [[2]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1R13-L19) [[3]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1L30-L35) [[4]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1L44-R56) [[5]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1L64-R81) [[6]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1L98-R101) [[7]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1L219-R233) [[8]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1L240-R243) [[9]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1R283-R296)

### Rule Documentation Enhancements:

* [`website/docs/rules/code-lang-shorthand.md`](diffhunk://#diff-52fdd05ab9363d42be689337a6ab0913b99f2cc6df446519a1ee7582bf4fc98aL1-R202): Replaced the first line header with a `<header>` tag and added detailed examples and explanations for incorrect and correct code usage.
* [`website/docs/rules/no-curly-quotes.md`](diffhunk://#diff-0beca2e870ea11f65da46491df93afa1f8c32461bd25539315ce191ceda90262L1-R2): Replaced the first line header with a `<header>` tag.
* [`website/docs/rules/no-double-spaces.md`](diffhunk://#diff-fc2a9b4ddc80bc8973502f72407b9d277fa531d9930b0625c072d5c1629182fbL1-R2): Replaced the first line header with a `<header>` tag.

### Rule Updates:

* [`packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js`](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bL115-R115): Changed the `recommended` property of the rule from `true` to `false`.

### Helper Updates:

* [`packages/eslint-plugin-mark/src/core/helpers/get-rule-docs-url/get-rule-docs-url.js`](diffhunk://#diff-cbaf53ba07139db6c8667add2c898b67090347128fae89fcbd642ca918e55c1dL9-R9): Updated the import statement to use `URL_RULE_DOCS` instead of `URL_RULES` and modified the function to use the new constant. [[1]](diffhunk://#diff-cbaf53ba07139db6c8667add2c898b67090347128fae89fcbd642ca918e55c1dL9-R9) [[2]](diffhunk://#diff-cbaf53ba07139db6c8667add2c898b67090347128fae89fcbd642ca918e55c1dL22-R22)