### PR TITLE
feat(eslint-plugin-mark): create `alt-text` rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5477,7 +5477,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/boundary": {
@@ -5886,7 +5885,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
       "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
@@ -5912,7 +5910,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
       "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
@@ -6561,7 +6558,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
       "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
@@ -6578,7 +6574,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -6945,7 +6940,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
@@ -6960,7 +6954,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6973,7 +6966,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
@@ -6989,7 +6981,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
@@ -7141,7 +7132,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
       "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.3",
@@ -7155,7 +7145,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -7219,7 +7208,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -9366,7 +9354,6 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
       "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
-      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -14771,7 +14758,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
@@ -15489,7 +15475,6 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
       "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^4.5.0"
@@ -15502,7 +15487,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
       "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "domhandler": "^5.0.3",
@@ -15516,7 +15500,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
       "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parse5": "^7.0.0"
@@ -16944,7 +16927,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/search-insights": {
@@ -18834,7 +18816,6 @@
       "version": "6.21.1",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
       "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -19916,7 +19897,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -19929,7 +19909,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -19942,7 +19921,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -20363,7 +20341,8 @@
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^6.3.0",
-        "@types/mdast": "^4.0.4"
+        "@types/mdast": "^4.0.4",
+        "cheerio": "^1.0.0"
       },
       "devDependencies": {
         "eslint": "^9.22.0"

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -76,7 +76,8 @@
   },
   "dependencies": {
     "@eslint/markdown": "^6.3.0",
-    "@types/mdast": "^4.0.4"
+    "@types/mdast": "^4.0.4",
+    "cheerio": "^1.0.0"
   },
   "devDependencies": {
     "eslint": "^9.22.0"

--- a/packages/eslint-plugin-mark/src/configs/all.js
+++ b/packages/eslint-plugin-mark/src/configs/all.js
@@ -32,6 +32,7 @@ export default function all(parserMode) {
     ...base(parserMode),
     name: `mark/all/${parserMode}`,
     rules: {
+      'mark/alt-text': 'error',
       'mark/code-lang-shorthand': 'error',
       'mark/no-curly-quotes': 'error',
       'mark/no-double-spaces': 'error',

--- a/packages/eslint-plugin-mark/src/rules/alt-text/alt-text.js
+++ b/packages/eslint-plugin-mark/src/rules/alt-text/alt-text.js
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Rule to enforce the use of alternative text for images.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import * as cheerio from 'cheerio';
+import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {import("@eslint/markdown").RuleModule} RuleModule
+ * @typedef {import("mdast").Image} Image
+ * @typedef {import("mdast").ImageReference} ImageReference
+ * @typedef {import("mdast").Html} Html
+ */
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const ruleName = getFileName(import.meta.url);
+
+// --------------------------------------------------------------------------------
+// Rule Definition
+// --------------------------------------------------------------------------------
+
+/** @type {RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      // @ts-ignore -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
+      name: ruleName,
+      recommended: true,
+      description: 'Enforce the use of alternative text for images.',
+      url: getRuleDocsUrl(ruleName),
+    },
+
+    messages: {
+      altText: 'Images should have an alternative text (alt text).',
+    },
+
+    language: 'markdown',
+
+    dialects: ['commonmark', 'gfm'],
+  },
+
+  create(context) {
+    return {
+      /** @param {Image} node */
+      image(node) {
+        if (node.alt === '') {
+          context.report({
+            // @ts-ignore -- TODO
+            node,
+            messageId: 'altText',
+          });
+        }
+      },
+
+      /** @param {ImageReference} node */
+      imageReference(node) {
+        if (node.alt === '') {
+          context.report({
+            // @ts-ignore -- TODO
+            node,
+            messageId: 'altText',
+          });
+        }
+      },
+
+      /** @param {Html} node */
+      html(node) {
+        const $ = cheerio.load(node.value);
+
+        $('img').each((_, elem) => {
+          if (!elem.attribs.alt) {
+            context.report({
+              // @ts-ignore -- TODO
+              node,
+              messageId: 'altText',
+            });
+          }
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-mark/src/rules/alt-text/alt-text.js
+++ b/packages/eslint-plugin-mark/src/rules/alt-text/alt-text.js
@@ -40,7 +40,7 @@ export default {
       // @ts-ignore -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
       name: ruleName,
       recommended: true,
-      description: 'Enforce the use of alternative text for images.',
+      description: 'Enforce the use of alternative text for images',
       url: getRuleDocsUrl(ruleName),
     },
 

--- a/packages/eslint-plugin-mark/src/rules/alt-text/alt-text.test.js
+++ b/packages/eslint-plugin-mark/src/rules/alt-text/alt-text.test.js
@@ -1,0 +1,151 @@
+/**
+ * @fileoverview Test for `alt-text.js`.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { test } from 'node:test';
+
+import { ruleTesterCommonmark, ruleTesterGfm } from '../../core/rule-tester/index.js';
+import rule from './alt-text.js';
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const { name } = rule.meta.docs;
+const altText = 'altText';
+
+// --------------------------------------------------------------------------------
+// Testcases
+// --------------------------------------------------------------------------------
+
+const tests = {
+  valid: [
+    {
+      name: 'Empty',
+      code: '',
+    },
+    {
+      name: 'Image node with alt text',
+      code: '![alt text](https://example.com/image.jpg)',
+    },
+    {
+      name: 'ImageReference node with alt text',
+      code: `
+![alt text][image]
+
+[image]: https://example.com/image.jpg
+`,
+    },
+    {
+      name: 'Html node with alt text',
+      code: '<img src="https://example.com/image.jpg" alt="alt text">',
+    },
+    {
+      name: 'Nested Html node with alt text',
+      code: `
+<div>
+  <img src="https://example.com/image.jpg" alt="alt text">
+</div>
+`,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'Image node without alt text',
+      code: '![](https://example.com/image.jpg)',
+      errors: [
+        {
+          messageId: altText,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 35,
+        },
+      ],
+    },
+    {
+      name: 'ImageReference node without alt text',
+      code: `
+![][image]
+
+[image]: https://example.com/image.jpg
+`,
+      errors: [
+        {
+          messageId: altText,
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 11,
+        },
+      ],
+    },
+    {
+      name: 'Html node without alt text',
+      code: '<img src="https://example.com/image.jpg">',
+      errors: [
+        {
+          messageId: altText,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 42,
+        },
+      ],
+    },
+    {
+      name: 'Html node with empty alt text',
+      code: '<img src="https://example.com/image.jpg" alt="">',
+      errors: [
+        {
+          messageId: altText,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 49,
+        },
+      ],
+    },
+    {
+      name: 'Nested Html node without alt text',
+      code: `
+<div>
+  <img src="https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg"><br>
+  <a href="https://www.google.com">google</a><br>
+  <img src="https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg"><br>
+</div>
+`,
+      errors: [
+        {
+          messageId: altText,
+          line: 2,
+          column: 1,
+          endLine: 6,
+          endColumn: 7,
+        },
+        {
+          messageId: altText,
+          line: 2,
+          column: 1,
+          endLine: 6,
+          endColumn: 7,
+        },
+      ],
+    },
+  ],
+};
+
+// --------------------------------------------------------------------------------
+// Test Runner
+// --------------------------------------------------------------------------------
+
+test(name, () => {
+  ruleTesterCommonmark.run(name, rule, tests);
+  ruleTesterGfm.run(name, rule, tests);
+});

--- a/packages/eslint-plugin-mark/src/rules/alt-text/index.js
+++ b/packages/eslint-plugin-mark/src/rules/alt-text/index.js
@@ -1,0 +1,3 @@
+import altText from './alt-text.js';
+
+export default altText;

--- a/packages/eslint-plugin-mark/src/rules/index.js
+++ b/packages/eslint-plugin-mark/src/rules/index.js
@@ -1,8 +1,9 @@
+import altText from './alt-text/index.js';
 import codeLangShorthand from './code-lang-shorthand/index.js';
 import noCurlyQuotes from './no-curly-quotes/index.js';
 import noDoubleSpaces from './no-double-spaces/index.js';
 
-export default [codeLangShorthand, noCurlyQuotes, noDoubleSpaces].reduce(
+export default [altText, codeLangShorthand, noCurlyQuotes, noDoubleSpaces].reduce(
   (rulesObject, rule) => {
     // @ts-ignore -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
     rulesObject[rule.meta.docs.name] = rule;

--- a/website/docs/rules/alt-text.md
+++ b/website/docs/rules/alt-text.md
@@ -1,0 +1,105 @@
+<!-- markdownlint-disable-next-line no-inline-html first-line-h1 -->
+<header v-html="$frontmatter.rule"></header>
+
+## Rule Details
+
+This rule is triggered when an image is missing alternative text (alt text)
+information.
+
+Alternative text is important for **accessibility** and describes the
+content of an image for people who may not be able to see it.
+
+Guidance for writing alternative text is available from the [W3C](https://www.w3.org/WAI/alt/),
+[Wikipedia](https://en.wikipedia.org/wiki/Alt_attribute), and [other locations](https://www.phase2technology.com/blog/no-more-excuses).
+
+Alternative text is commonly specified inline as:
+
+```md
+![alternative text](https://example.com/image.jpg)
+```
+
+Or with reference syntax as:
+
+```md
+![alternative text][ref]
+
+[ref]: https://example.com/image.jpg "Optional title"
+```
+
+Or with HTML as:
+
+```html
+<img src="https://example.com/image.jpg" alt="alternative text" />
+```
+
+### :x: Incorrect {#incorrect}
+
+Examples of **incorrect** code for this rule:
+
+::: code-group
+
+```md [incorrect.md]
+![](https://example.com/image.jpg)
+
+![][image]
+
+[image]: https://example.com/image.jpg
+
+<img src="https://example.com/image.jpg" />
+
+<img src="https://example.com/image.jpg" alt="" />
+```
+
+```js [eslint.config.mjs] {5}
+export default [
+  // ...
+  {
+    rules: {
+      'mark/alt-text': 'error', // [!code focus]
+    },
+  },
+  // ...
+];
+```
+
+:::
+
+### :white_check_mark: Correct {#correct}
+
+Examples of **correct** code for this rule:
+
+::: code-group
+
+```md [correct.md]
+![alternative text](https://example.com/image.jpg)
+
+![alternative text][image]
+
+[image]: https://example.com/image.jpg
+
+<img src="https://example.com/image.jpg" alt="alternative text" />
+```
+
+```js [eslint.config.mjs] {5}
+export default [
+  // ...
+  {
+    rules: {
+      'mark/alt-text': 'error', // [!code focus]
+    },
+  },
+  // ...
+];
+```
+
+## Options
+
+No options are available for this rule.
+
+## AST
+
+This rule applies to the [`Image`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#image), [`ImageReference`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#imagereference), and [`Html`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#html) nodes.
+
+## Prior Art
+
+- [markdownlint: MD045](https://github.com/DavidAnson/markdownlint/blob/main/doc/md045.md)


### PR DESCRIPTION
This pull request introduces a new ESLint rule to enforce the use of alternative text for images in the `eslint-plugin-mark` package. The most important changes include adding the new rule, updating the configuration, and creating corresponding tests and documentation.

### New Rule Addition:
* [`packages/eslint-plugin-mark/src/rules/alt-text/alt-text.js`](diffhunk://#diff-6560944db191e902d3ac04b45b164f66c5bd84703cfc914c50c75fc942048c9fR1-R96): Added a new rule to enforce the use of alternative text for images. This rule checks for `Image`, `ImageReference`, and `Html` nodes to ensure they contain `alt` text.

### Configuration Updates:
* [`packages/eslint-plugin-mark/src/configs/all.js`](diffhunk://#diff-dcdf50541cdda584e7b5e20419349e2a8760d86d4d140d12dbd1d97b3084703fR35): Added the `mark/alt-text` rule to the list of rules enforced by the `all` configuration.
* [`packages/eslint-plugin-mark/src/rules/index.js`](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R1-R6): Included the new `alt-text` rule in the list of available rules.

### Testing:
* [`packages/eslint-plugin-mark/src/rules/alt-text/alt-text.test.js`](diffhunk://#diff-4bf5c4182b3bd7fbce9deac2a8aaa8d943d3eff131d6427495172d55c4f55106R1-R151): Created tests for the `alt-text` rule to ensure it correctly identifies valid and invalid cases of image elements without alternative text.

### Documentation:
* [`website/docs/rules/alt-text.md`](diffhunk://#diff-05707a63cf0061d03420be2cfcb93cb508699d7df712e45a57eb6faa2544b93eR1-R105): Added documentation for the new `alt-text` rule, including examples of correct and incorrect code, and references to accessibility guidelines.

### Dependency Update:
* [`packages/eslint-plugin-mark/package.json`](diffhunk://#diff-9b9400561d26b4f60200e53b8fbb54b0ef18955f8348a54f396c6ac386667a0dL79-R80): Added `cheerio` as a new dependency to parse and manipulate HTML in the `alt-text` rule.