### PR TITLE
feat(eslint-plugin-mark): create `no-emojis` rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20342,7 +20342,8 @@
       "dependencies": {
         "@eslint/markdown": "^6.3.0",
         "@types/mdast": "^4.0.4",
-        "cheerio": "^1.0.0"
+        "cheerio": "^1.0.0",
+        "emoji-regex": "^10.4.0"
       },
       "devDependencies": {
         "eslint": "^9.23.0"
@@ -20359,6 +20360,12 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "packages/eslint-plugin-mark/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "license": "MIT"
     },
     "website": {
       "version": "0.1.0-canary.0",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -77,7 +77,8 @@
   "dependencies": {
     "@eslint/markdown": "^6.3.0",
     "@types/mdast": "^4.0.4",
-    "cheerio": "^1.0.0"
+    "cheerio": "^1.0.0",
+    "emoji-regex": "^10.4.0"
   },
   "devDependencies": {
     "eslint": "^9.23.0"

--- a/packages/eslint-plugin-mark/src/configs/all.js
+++ b/packages/eslint-plugin-mark/src/configs/all.js
@@ -33,10 +33,10 @@ export default function all(parserMode) {
     name: `mark/all/${parserMode}`,
     rules: {
       'mark/alt-text': 'error',
-      'mark/code-lang-shorthand': 'error',
+      'mark/code-lang-shorthand': 'warn',
       'mark/no-curly-quotes': 'error',
       'mark/no-double-spaces': 'error',
-      'mark/no-emojis': 'error',
+      'mark/no-emojis': 'warn',
     },
   };
 }

--- a/packages/eslint-plugin-mark/src/configs/all.js
+++ b/packages/eslint-plugin-mark/src/configs/all.js
@@ -36,6 +36,7 @@ export default function all(parserMode) {
       'mark/code-lang-shorthand': 'error',
       'mark/no-curly-quotes': 'error',
       'mark/no-double-spaces': 'error',
+      'mark/no-emojis': 'error',
     },
   };
 }

--- a/packages/eslint-plugin-mark/src/rules/index.js
+++ b/packages/eslint-plugin-mark/src/rules/index.js
@@ -2,12 +2,16 @@ import altText from './alt-text/index.js';
 import codeLangShorthand from './code-lang-shorthand/index.js';
 import noCurlyQuotes from './no-curly-quotes/index.js';
 import noDoubleSpaces from './no-double-spaces/index.js';
+import noEmojis from './no-emojis/index.js';
 
-export default [altText, codeLangShorthand, noCurlyQuotes, noDoubleSpaces].reduce(
-  (rulesObject, rule) => {
-    // @ts-expect-error -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
-    rulesObject[rule.meta.docs.name] = rule;
-    return rulesObject;
-  },
-  {},
-);
+export default [
+  altText,
+  codeLangShorthand,
+  noCurlyQuotes,
+  noDoubleSpaces,
+  noEmojis,
+].reduce((rulesObject, rule) => {
+  // @ts-expect-error -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
+  rulesObject[rule.meta.docs.name] = rule;
+  return rulesObject;
+}, {});

--- a/packages/eslint-plugin-mark/src/rules/no-emojis/index.js
+++ b/packages/eslint-plugin-mark/src/rules/no-emojis/index.js
@@ -1,0 +1,3 @@
+import noEmojis from './no-emojis.js';
+
+export default noEmojis;

--- a/packages/eslint-plugin-mark/src/rules/no-emojis/no-emojis.js
+++ b/packages/eslint-plugin-mark/src/rules/no-emojis/no-emojis.js
@@ -1,0 +1,92 @@
+/**
+ * @fileoverview Rule to disallow emojis in text.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import emojiRegex from 'emoji-regex';
+
+import { textHandler } from '../../core/ast/index.js';
+import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {import("@eslint/markdown").RuleModule} RuleModule
+ * @typedef {import("../../core/types.d.ts").TextExt} TextExt
+ */
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const ruleName = getFileName(import.meta.url);
+
+// --------------------------------------------------------------------------------
+// Rule Definition
+// --------------------------------------------------------------------------------
+
+/** @type {RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      // @ts-expect-error -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
+      name: ruleName,
+      recommended: false,
+      description: 'Disallow emojis in text',
+      url: getRuleDocsUrl(ruleName),
+    },
+
+    messages: {
+      noEmojis: 'Emojis are not allowed.',
+    },
+
+    language: 'markdown',
+
+    dialects: ['commonmark', 'gfm'],
+  },
+
+  create(context) {
+    return {
+      /** @param {TextExt} node */
+      text(node) {
+        textHandler(context, node);
+
+        node.children.forEach(textLineNode => {
+          const matches = [...textLineNode.value.matchAll(emojiRegex())];
+
+          if (matches.length > 0) {
+            matches.forEach(match => {
+              const emojiLength = match[0].length;
+
+              const matchIndexStart = match.index;
+              const matchIndexEnd = matchIndexStart + emojiLength;
+
+              context.report({
+                loc: {
+                  start: {
+                    line: textLineNode.position.start.line,
+                    column: textLineNode.position.start.column + matchIndexStart,
+                  },
+                  end: {
+                    line: textLineNode.position.start.line,
+                    column: textLineNode.position.start.column + matchIndexEnd,
+                  },
+                },
+
+                messageId: 'noEmojis',
+              });
+            });
+          }
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-mark/src/rules/no-emojis/no-emojis.test.js
+++ b/packages/eslint-plugin-mark/src/rules/no-emojis/no-emojis.test.js
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Test for `no-emojis.js`.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { test } from 'node:test';
+
+import { ruleTesterCommonmark, ruleTesterGfm } from '../../core/rule-tester/index.js';
+import rule from './no-emojis.js';
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const { name } = rule.meta.docs;
+const noEmojis = 'noEmojis';
+
+// --------------------------------------------------------------------------------
+// Testcases
+// --------------------------------------------------------------------------------
+
+const tests = {
+  valid: [
+    {
+      name: 'Empty',
+      code: '',
+    },
+    {
+      name: 'Empty string',
+      code: '  ',
+    },
+    {
+      name: 'Text without emojis',
+      code: 'Hello, world!',
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'Singleline emoji',
+      code: 'Hello, 😊!',
+      errors: [
+        {
+          messageId: noEmojis,
+          line: 1,
+          column: 8,
+        },
+      ],
+    },
+    {
+      name: 'Multiline emojis',
+      code: `Hi, 😊
+🦄!`,
+      errors: [
+        {
+          messageId: noEmojis,
+          line: 1,
+          column: 5,
+        },
+        {
+          messageId: noEmojis,
+          line: 2,
+          column: 1,
+        },
+      ],
+    },
+  ],
+};
+
+// --------------------------------------------------------------------------------
+// Test Runner
+// --------------------------------------------------------------------------------
+
+test(name, () => {
+  ruleTesterCommonmark.run(name, rule, tests);
+  ruleTesterGfm.run(name, rule, tests);
+});

--- a/website/docs/rules/no-emojis.md
+++ b/website/docs/rules/no-emojis.md
@@ -1,0 +1,80 @@
+<!-- markdownlint-disable-next-line no-inline-html first-line-h1 -->
+<header v-html="$frontmatter.rule"></header>
+
+## Rule Details
+
+Some websites and Markdown parsers handle emojis natively or provide their own plugins for support. Instead of using raw emojis like `😃`, you can use the `:smiley:`-style syntax, which places colons around the emoji name.
+
+The purpose of this rule is to discourage the use of raw emojis in Markdown files and encourage the use of the `:smiley:`-style syntax for better compatibility.
+
+For a full list of supported emojis, you can refer to the [Emoji Cheat Sheet](https://www.webfx.com/tools/emoji-cheat-sheet/) or [emoji-cheat-sheet](https://github.com/ikatyang/emoji-cheat-sheet).
+
+Platforms like [GitHub](https://github.com) and Markdown plugins such as [`remark-emoji`](https://github.com/rhysd/remark-emoji) and [`markdown-it-emoji`](https://github.com/markdown-it/markdown-it-emoji) also support this feature.
+
+### :x: Incorrect {#incorrect}
+
+Examples of **incorrect** code for this rule:
+
+::: code-group
+
+```md [incorrect.md] /😃/ /🦄/ /👍/
+Smiley 😃
+
+Unicorn 🦄
+
++1 👍
+```
+
+```js [eslint.config.mjs] {5}
+export default [
+  // ...
+  {
+    rules: {
+      'mark/no-emojis': 'error', // [!code focus]
+    },
+  },
+  // ...
+];
+```
+
+:::
+
+### :white_check_mark: Correct {#correct}
+
+Examples of **correct** code for this rule:
+
+::: code-group
+
+```md [correct.md]
+Smiley :smiley:
+
+Unicorn :unicorn:
+
++1 :+1:
+```
+
+```js [eslint.config.mjs] {5}
+export default [
+  // ...
+  {
+    rules: {
+      'mark/no-emojis': 'error', // [!code focus]
+    },
+  },
+  // ...
+];
+```
+
+:::
+
+## Limitations
+
+This rule uses [Emoji Regex](https://github.com/mathiasbynens/emoji-regex) internally to match emojis. Emojis that are not supported by this regex will not be detected by this rule.
+
+## Options
+
+No options are available for this rule.
+
+## AST
+
+This rule applies only to the [`Text`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#text) node.


### PR DESCRIPTION
This pull request introduces a new ESLint rule to disallow emojis in text, along with the necessary updates to integrate this rule into the existing codebase. The most important changes include adding the `emoji-regex` dependency, updating the rule configurations, and adding the new rule with its corresponding tests and documentation.

### New ESLint Rule for Disallowing Emojis:

* **Dependency Addition:**
  * Added `emoji-regex` to the dependencies in `package.json`.

* **Rule Configuration:**
  * Updated `packages/eslint-plugin-mark/src/configs/all.js` to add the `mark/no-emojis` rule and set it to `warn`.
  * Imported and included the `no-emojis` rule in the rules index file `packages/eslint-plugin-mark/src/rules/index.js`.

* **New Rule Implementation:**
  * Created the `no-emojis` rule in `packages/eslint-plugin-mark/src/rules/no-emojis/no-emojis.js` to disallow emojis in text using `emoji-regex`.
  * Exported the `no-emojis` rule in `packages/eslint-plugin-mark/src/rules/no-emojis/index.js`.

* **Testing:**
  * Added tests for the `no-emojis` rule in `packages/eslint-plugin-mark/src/rules/no-emojis/no-emojis.test.js`.

* **Documentation:**
  * Documented the `no-emojis` rule in `website/docs/rules/no-emojis.md`, including examples of correct and incorrect usage.