### PR TITLE
chore(*): update prettier commands to include `--ignore-unknown` option

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   '*': [
-    'npx prettier --check',
+    'npx prettier --check --ignore-unknown',
     'npx editorconfig-checker -config .editorconfig-checker.json',
   ],
   '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,md}': 'npx eslint',

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "start:website": "npm run start -w website",
     "fix": "concurrently \"npm:fix:*\"",
     "fix:eslint": "npx eslint --fix",
-    "fix:prettier": "npx prettier . --write",
+    "fix:prettier": "npx prettier . --write --ignore-unknown",
     "lint": "concurrently \"npm:lint:*\"",
     "lint:eslint": "npx eslint",
-    "lint:prettier": "npx prettier . --check",
+    "lint:prettier": "npx prettier . --check --ignore-unknown",
     "lint:editorconfig": "npx editorconfig-checker -config .editorconfig-checker.json",
     "lint:markdownlint": "npx markdownlint **/*.md",
     "lint:textlint": "npx textlint -f pretty-error **/*.md"


### PR DESCRIPTION
This pull request includes updates to the `lint-staged.config.js` and `package.json` files to improve the handling of unknown file types by the Prettier tool.

Changes to improve Prettier handling:

* [`lint-staged.config.js`](diffhunk://#diff-29c15f0b5d8d1144bd22153c302cde16c2de092d65b122a618cbdb3023336346L3-R3): Updated the Prettier command to include the `--ignore-unknown` flag, which helps to prevent errors when encountering unknown file types.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L30-R33): Added the `--ignore-unknown` flag to both the `fix:prettier` and `lint:prettier` scripts to ensure consistent handling of unknown file types across different commands.