### PR TITLE
feat(eslint-plugin-mark): create `heading-id` rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,8 @@ indent_size = 2
 trim_trailing_whitespace = true
 max_line_length = 100000
 
+[*.md]
+trim_trailing_whitespace = false
+
 [*.{h,c,cpp}]
 indent_size = unset

--- a/package-lock.json
+++ b/package-lock.json
@@ -20377,7 +20377,7 @@
         "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "vitepress": "^1.6.3",
-        "vitepress-plugin-group-icons": "^1.3.7"
+        "vitepress-plugin-group-icons": "^1.3.8"
       }
     },
     "website/node_modules/@shikijs/core": {

--- a/packages/eslint-plugin-mark/src/configs/all.js
+++ b/packages/eslint-plugin-mark/src/configs/all.js
@@ -34,6 +34,7 @@ export default function all(parserMode) {
     rules: {
       'mark/alt-text': 'error',
       'mark/code-lang-shorthand': 'warn',
+      'mark/heading-id': 'warn',
       'mark/no-curly-quotes': 'error',
       'mark/no-double-spaces': 'error',
       'mark/no-emojis': 'warn',

--- a/packages/eslint-plugin-mark/src/rules/heading-id/.gitkeep
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/.gitkeep
@@ -1,1 +1,0 @@
-https://github.com/textlint-rule/textlint-rule-require-header-id

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
@@ -41,6 +41,8 @@ export default {
       url: getRuleDocsUrl(ruleName),
     },
 
+    fixable: 'code',
+
     schema: [
       {
         enum: ['always', 'never'],
@@ -76,7 +78,8 @@ export default {
 
     messages: {
       headingIdAlways: 'Headings should have an ID attribute.',
-      headingIdNever: 'Headings should not have an ID attribute.',
+      headingIdNever:
+        'Headings should not have an ID attribute. Remove the `{{ headingId }}`.',
     },
 
     language: 'markdown',
@@ -129,7 +132,21 @@ export default {
               },
             },
 
+            data: {
+              headingId: match[0],
+            },
+
             messageId: 'headingIdNever',
+
+            fix(fixer) {
+              return fixer.replaceTextRange(
+                [
+                  node.position.start.offset + matchIndexStart,
+                  node.position.start.offset + matchIndexEnd,
+                ],
+                '',
+              );
+            },
           });
         }
       },

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Rule to enforce the use of heading IDs.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {import("@eslint/markdown").RuleModule} RuleModule
+ * @typedef {import("mdast").Heading} Heading
+ */
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const ruleName = getFileName(import.meta.url);
+
+// --------------------------------------------------------------------------------
+// Rule Definition
+// --------------------------------------------------------------------------------
+
+/** @type {RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      // @ts-expect-error -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
+      name: ruleName,
+      recommended: false,
+      description: 'Enforce the use of heading IDs',
+      url: getRuleDocsUrl(ruleName),
+    },
+
+    messages: {
+      headingId: 'Headings should have an ID attribute.',
+    },
+
+    language: 'markdown',
+
+    dialects: ['commonmark', 'gfm'],
+  },
+
+  create(context) {
+    return {
+      /** @param {Heading} node */
+      heading(node) {
+        const regex = /{#[^}]+}[ \t]*$/g;
+
+        // @ts-expect-error -- TODO: https://github.com/eslint/markdown/issues/323
+        const matches = [...context.sourceCode.getText(node).matchAll(regex)];
+
+        if (matches.length === 0) {
+          context.report({
+            loc: {
+              start: {
+                line: node.position.start.line,
+                column: node.position.end.column,
+              },
+              end: {
+                line: node.position.start.line,
+                column: node.position.end.column,
+              },
+            },
+
+            messageId: 'headingId',
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
@@ -91,14 +91,14 @@ export default {
     return {
       /** @param {Heading} node */
       heading(node) {
-        const mode = context.options[0];
         // @ts-expect-error -- TODO
-        const { leftDelimiter, rightDelimiter } = context.options[1];
+        const [mode, { leftDelimiter, rightDelimiter, ignoreDepth }] = context.options;
+
+        if (ignoreDepth.includes(node.depth)) return;
 
         const regex = new RegExp(
           `${leftDelimiter}#[^${rightDelimiter}]+${rightDelimiter}[ \t]*$`,
         );
-
         // @ts-expect-error -- TODO: https://github.com/eslint/markdown/issues/323
         const match = context.sourceCode.getText(node).match(regex);
 

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
@@ -92,9 +92,12 @@ export default {
       /** @param {Heading} node */
       heading(node) {
         const mode = context.options[0];
-        // const { leftDelimiter, rightDelimiter, ignoreDepth } = context.options[1];
+        // @ts-expect-error -- TODO
+        const { leftDelimiter, rightDelimiter } = context.options[1];
 
-        const regex = /{#[^}]+}[ \t]*$/;
+        const regex = new RegExp(
+          `${leftDelimiter}#[^${rightDelimiter}]+${rightDelimiter}[ \t]*$`,
+        );
 
         // @ts-expect-error -- TODO: https://github.com/eslint/markdown/issues/323
         const match = context.sourceCode.getText(node).match(regex);

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
@@ -17,7 +17,8 @@ import rule from './heading-id.js';
 // --------------------------------------------------------------------------------
 
 const { name } = rule.meta.docs;
-const headingId = 'headingId';
+const headingIdAlways = 'headingIdAlways';
+const headingIdNever = 'headingIdNever';
 
 // --------------------------------------------------------------------------------
 // Testcases
@@ -64,6 +65,38 @@ const tests = {
       name: 'h1 heading ID and trailing spaces',
       code: '# Heading {#id}  ',
     },
+
+    // Never option
+    {
+      name: 'No h1 heading ID',
+      code: '# Heading',
+      options: ['never'],
+    },
+    {
+      name: 'No h2 heading ID',
+      code: '## Heading',
+      options: ['never'],
+    },
+    {
+      name: 'No h3 heading ID',
+      code: '### Heading',
+      options: ['never'],
+    },
+    {
+      name: 'No h4 heading ID',
+      code: '#### Heading',
+      options: ['never'],
+    },
+    {
+      name: 'No h5 heading ID',
+      code: '##### Heading',
+      options: ['never'],
+    },
+    {
+      name: 'No h6 heading ID',
+      code: '###### Heading',
+      options: ['never'],
+    },
   ],
 
   invalid: [
@@ -73,7 +106,7 @@ const tests = {
       code: '# Heading',
       errors: [
         {
-          messageId: headingId,
+          messageId: headingIdAlways,
           line: 1,
           column: 10,
           endLine: 1,
@@ -86,7 +119,7 @@ const tests = {
       code: '## Heading',
       errors: [
         {
-          messageId: headingId,
+          messageId: headingIdAlways,
           line: 1,
           column: 11,
           endLine: 1,
@@ -99,7 +132,7 @@ const tests = {
       code: '### Heading',
       errors: [
         {
-          messageId: headingId,
+          messageId: headingIdAlways,
           line: 1,
           column: 12,
           endLine: 1,
@@ -112,7 +145,7 @@ const tests = {
       code: '#### Heading',
       errors: [
         {
-          messageId: headingId,
+          messageId: headingIdAlways,
           line: 1,
           column: 13,
           endLine: 1,
@@ -125,7 +158,7 @@ const tests = {
       code: '##### Heading',
       errors: [
         {
-          messageId: headingId,
+          messageId: headingIdAlways,
           line: 1,
           column: 14,
           endLine: 1,
@@ -138,7 +171,7 @@ const tests = {
       code: '###### Heading',
       errors: [
         {
-          messageId: headingId,
+          messageId: headingIdAlways,
           line: 1,
           column: 15,
           endLine: 1,
@@ -153,7 +186,7 @@ const tests = {
       code: '# Heading {#}',
       errors: [
         {
-          messageId: headingId,
+          messageId: headingIdAlways,
           line: 1,
           column: 14,
           endLine: 1,
@@ -166,13 +199,99 @@ const tests = {
       code: '# Heading { #id}',
       errors: [
         {
-          messageId: headingId,
+          messageId: headingIdAlways,
           line: 1,
           column: 17,
           endLine: 1,
           endColumn: 17,
         },
       ],
+    },
+
+    // Never option
+    {
+      name: 'h1 heading ID exists',
+      code: '# Heading {#id}',
+      errors: [
+        {
+          messageId: headingIdNever,
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+      options: ['never'],
+    },
+    {
+      name: 'h2 heading ID exists',
+      code: '## Heading {#id}',
+      errors: [
+        {
+          messageId: headingIdNever,
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 17,
+        },
+      ],
+      options: ['never'],
+    },
+    {
+      name: 'h3 heading ID exists',
+      code: '### Heading {#id}',
+      errors: [
+        {
+          messageId: headingIdNever,
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 18,
+        },
+      ],
+      options: ['never'],
+    },
+    {
+      name: 'h4 heading ID exists',
+      code: '#### Heading {#id}',
+      errors: [
+        {
+          messageId: headingIdNever,
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 19,
+        },
+      ],
+      options: ['never'],
+    },
+    {
+      name: 'h5 heading ID exists',
+      code: '##### Heading {#id}',
+      errors: [
+        {
+          messageId: headingIdNever,
+          line: 1,
+          column: 15,
+          endLine: 1,
+          endColumn: 20,
+        },
+      ],
+      options: ['never'],
+    },
+    {
+      name: 'h6 heading ID exists',
+      code: '###### Heading {#id}',
+      errors: [
+        {
+          messageId: headingIdNever,
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 21,
+        },
+      ],
+      options: ['never'],
     },
   ],
 };

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
@@ -66,7 +66,7 @@ const tests = {
       code: '# Heading {#id}  ',
     },
 
-    // Never option
+    // `never` option
     {
       name: 'No h1 heading ID',
       code: '# Heading',

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
@@ -1,0 +1,187 @@
+/**
+ * @fileoverview Test for `heading-id.js`.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { test } from 'node:test';
+
+import { ruleTesterCommonmark, ruleTesterGfm } from '../../core/rule-tester/index.js';
+import rule from './heading-id.js';
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const { name } = rule.meta.docs;
+const headingId = 'headingId';
+
+// --------------------------------------------------------------------------------
+// Testcases
+// --------------------------------------------------------------------------------
+
+const tests = {
+  valid: [
+    // Default
+    {
+      name: 'Empty',
+      code: '',
+    },
+    {
+      name: 'Empty String',
+      code: '  ',
+    },
+    {
+      name: 'Correct h1 heading ID',
+      code: '# Heading {#id}',
+    },
+    {
+      name: 'Correct h2 heading ID',
+      code: '## Heading {#id}',
+    },
+    {
+      name: 'Correct h3 heading ID',
+      code: '### Heading {#id}',
+    },
+    {
+      name: 'Correct h4 heading ID',
+      code: '#### Heading {#id}',
+    },
+    {
+      name: 'Correct h5 heading ID',
+      code: '##### Heading {#id}',
+    },
+    {
+      name: 'Correct h6 heading ID',
+      code: '###### Heading {#id}',
+    },
+
+    // Default: Edge Cases
+    {
+      name: 'h1 heading ID and trailing spaces',
+      code: '# Heading {#id}  ',
+    },
+  ],
+
+  invalid: [
+    // Default
+    {
+      name: 'Missing h1 heading ID',
+      code: '# Heading',
+      errors: [
+        {
+          messageId: headingId,
+          line: 1,
+          column: 10,
+          endLine: 1,
+          endColumn: 10,
+        },
+      ],
+    },
+    {
+      name: 'Missing h2 heading ID',
+      code: '## Heading',
+      errors: [
+        {
+          messageId: headingId,
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 11,
+        },
+      ],
+    },
+    {
+      name: 'Missing h3 heading ID',
+      code: '### Heading',
+      errors: [
+        {
+          messageId: headingId,
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 12,
+        },
+      ],
+    },
+    {
+      name: 'Missing h4 heading ID',
+      code: '#### Heading',
+      errors: [
+        {
+          messageId: headingId,
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      name: 'Missing h5 heading ID',
+      code: '##### Heading',
+      errors: [
+        {
+          messageId: headingId,
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      name: 'Missing h6 heading ID',
+      code: '###### Heading',
+      errors: [
+        {
+          messageId: headingId,
+          line: 1,
+          column: 15,
+          endLine: 1,
+          endColumn: 15,
+        },
+      ],
+    },
+
+    // Default: Edge Cases
+    {
+      name: 'h1 heading ID with nothing',
+      code: '# Heading {#}',
+      errors: [
+        {
+          messageId: headingId,
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      name: 'h1 heading ID with leading space',
+      code: '# Heading { #id}',
+      errors: [
+        {
+          messageId: headingId,
+          line: 1,
+          column: 17,
+          endLine: 1,
+          endColumn: 17,
+        },
+      ],
+    },
+  ],
+};
+
+// --------------------------------------------------------------------------------
+// Test Runner
+// --------------------------------------------------------------------------------
+
+test(name, () => {
+  ruleTesterCommonmark.run(name, rule, tests);
+  ruleTesterGfm.run(name, rule, tests);
+});

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
@@ -212,6 +212,7 @@ const tests = {
     {
       name: 'h1 heading ID exists',
       code: '# Heading {#id}',
+      output: '# Heading ',
       errors: [
         {
           messageId: headingIdNever,
@@ -226,6 +227,7 @@ const tests = {
     {
       name: 'h2 heading ID exists',
       code: '## Heading {#id}',
+      output: '## Heading ',
       errors: [
         {
           messageId: headingIdNever,
@@ -240,6 +242,7 @@ const tests = {
     {
       name: 'h3 heading ID exists',
       code: '### Heading {#id}',
+      output: '### Heading ',
       errors: [
         {
           messageId: headingIdNever,
@@ -254,6 +257,7 @@ const tests = {
     {
       name: 'h4 heading ID exists',
       code: '#### Heading {#id}',
+      output: '#### Heading ',
       errors: [
         {
           messageId: headingIdNever,
@@ -268,6 +272,7 @@ const tests = {
     {
       name: 'h5 heading ID exists',
       code: '##### Heading {#id}',
+      output: '##### Heading ',
       errors: [
         {
           messageId: headingIdNever,
@@ -282,6 +287,7 @@ const tests = {
     {
       name: 'h6 heading ID exists',
       code: '###### Heading {#id}',
+      output: '###### Heading ',
       errors: [
         {
           messageId: headingIdNever,

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
@@ -97,6 +97,30 @@ const tests = {
       code: '###### Heading',
       options: ['never'],
     },
+
+    // Custom Delimiters
+    {
+      name: 'Custom Delimiters `[`, `]`',
+      code: '# Heading [#id]',
+      options: [
+        'always',
+        {
+          leftDelimiter: '\\[',
+          rightDelimiter: '\\]',
+        },
+      ],
+    },
+    {
+      name: 'Custom Delimiters `|`, `|`',
+      code: '# Heading |#id|',
+      options: [
+        'always',
+        {
+          leftDelimiter: '\\|',
+          rightDelimiter: '\\|',
+        },
+      ],
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
@@ -98,7 +98,7 @@ const tests = {
       options: ['never'],
     },
 
-    // Custom Delimiters
+    // `leftDelimiter` and `rightDelimiter` option
     {
       name: 'Custom Delimiters `[`, `]`',
       code: '# Heading [#id]',
@@ -118,6 +118,28 @@ const tests = {
         {
           leftDelimiter: '\\|',
           rightDelimiter: '\\|',
+        },
+      ],
+    },
+
+    // `ignoreDepth` option
+    {
+      name: 'Ignore h1 heading ID',
+      code: '# Heading',
+      options: [
+        'always',
+        {
+          ignoreDepth: [1],
+        },
+      ],
+    },
+    {
+      name: 'Ignore h1, h2, h3 heading ID',
+      code: '# Heading 1\n\n## Heading 2\n\n### Heading 3',
+      options: [
+        'always',
+        {
+          ignoreDepth: [1, 2, 3],
         },
       ],
     },

--- a/packages/eslint-plugin-mark/src/rules/heading-id/index.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/index.js
@@ -1,0 +1,3 @@
+import headingId from './heading-id.js';
+
+export default headingId;

--- a/packages/eslint-plugin-mark/src/rules/index.js
+++ b/packages/eslint-plugin-mark/src/rules/index.js
@@ -1,5 +1,6 @@
 import altText from './alt-text/index.js';
 import codeLangShorthand from './code-lang-shorthand/index.js';
+import headingId from './heading-id/index.js';
 import noCurlyQuotes from './no-curly-quotes/index.js';
 import noDoubleSpaces from './no-double-spaces/index.js';
 import noEmojis from './no-emojis/index.js';
@@ -7,6 +8,7 @@ import noEmojis from './no-emojis/index.js';
 export default [
   altText,
   codeLangShorthand,
+  headingId,
   noCurlyQuotes,
   noDoubleSpaces,
   noEmojis,

--- a/packages/eslint-plugin-mark/src/rules/no-invalid-control-characters/.gitkeep
+++ b/packages/eslint-plugin-mark/src/rules/no-invalid-control-characters/.gitkeep
@@ -1,1 +1,2 @@
-https://github.com/textlint-rule/textlint-rule-no-invalid-control-character
+- <https://github.com/textlint-rule/textlint-rule-no-invalid-control-character>
+- <https://eslint.org/docs/latest/rules/no-control-regex#rule-details>

--- a/packages/eslint-plugin-mark/src/rules/no-zero-width-spaces/.gitkeep
+++ b/packages/eslint-plugin-mark/src/rules/no-zero-width-spaces/.gitkeep
@@ -1,0 +1,1 @@
+<https://eslint.org/docs/latest/rules/no-irregular-whitespace>

--- a/website/docs/rules/heading-id.md
+++ b/website/docs/rules/heading-id.md
@@ -1,0 +1,136 @@
+<!-- markdownlint-disable-next-line no-inline-html first-line-h1 -->
+<header v-html="$frontmatter.rule"></header>
+
+## Rule Details
+
+Some Markdown parsers or plugins, like [`@mdit/plugin-attrs`](https://mdit-plugins.github.io/attrs.html), support custom heading IDs which can be used to add IDs to headings.
+
+Heading IDs are helpful for linking to specific sections within a document and are supported by some websites and markdown parsers through the `{#id}` syntax. These IDs not only provide improved accessibility, allowing screen readers to create a navigable table of contents, but also enhance SEO by helping search engines understand the structure of the document and deliver better search results.
+
+When building websites with internationalization in mind, it's recommended to use English words for heading IDs. This is because certain languages may cause issues with URL encoding, leading to characters like `%20` or `%C3%A9` when IDs are encoded, which can make it difficult for people to recognize.
+
+### :x: Incorrect
+
+Examples of **incorrect** code for this rule:
+
+#### Default
+
+::: code-group
+
+```md [incorrect.md] / ⁡/
+# Heading 1 ⁡
+
+## Heading 2 ⁡
+
+### Heading 3 ⁡
+
+#### Heading 4 ⁡
+
+##### Heading 5 ⁡
+
+###### Heading 6 ⁡
+
+# Heading {#} ⁡
+
+# Heading { #id} ⁡
+```
+
+```js [eslint.config.mjs] {5}
+export default [
+  // ...
+  {
+    rules: {
+      'mark/heading-id': 'error', // [!code focus]
+    },
+  },
+  // ...
+];
+```
+
+:::
+
+### :white_check_mark: Correct
+
+Examples of **correct** code for this rule:
+
+#### Default
+
+::: code-group
+
+```md [correct.md]
+# Heading 1 {#heading-1}
+
+## Heading 2 {#heading-2}
+
+### Heading 3 {#heading-3}
+
+#### Heading 4 {#heading-4}
+
+##### Heading 5 {#heading-5}
+
+###### Heading 6 {#heading-6}
+```
+
+```js [eslint.config.mjs] {5}
+export default [
+  // ...
+  {
+    rules: {
+      'mark/heading-id': 'error', // [!code focus]
+    },
+  },
+  // ...
+];
+```
+
+:::
+
+## Options
+
+```js
+'mark/heading-id': [
+  'error',
+  'always',
+  {
+    leftDelimiter: '{',
+    rightDelimiter: '}',
+    ignoreDepth: [],
+  }
+]
+```
+
+### First Option
+
+#### `'always'` | `'never'`
+
+> Default: `'always'`
+
+`'always'` enforces the presence of heading IDs. `'never'` disallows heading IDs.
+
+### Second Option
+
+#### `leftDelimiter`
+
+> Default: `'{'`
+
+The left delimiter to use for heading IDs.
+
+#### `rightDelimiter`
+
+> Default: `'}'`
+
+The right delimiter to use for heading IDs.
+
+#### `ignoreDepth`
+
+> Default: `[]`
+
+An array of heading depths to ignore. For example, `[1, 2]` would ignore the first and second level headings.
+
+## AST
+
+This rule applies only to the [`Heading`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#heading) node.  
+
+## Prior Art
+
+- [textlint-rule-require-header-id](https://github.com/textlint-rule/textlint-rule-require-header-id)

--- a/website/docs/rules/heading-id.md
+++ b/website/docs/rules/heading-id.md
@@ -113,11 +113,23 @@ export default [
 
 > Default: `'{'`
 
+::: warning
+
+Please note that if you use a custom delimiter, it must be escaped since it is used in a regular expression. For example, if you want to use `'['`, you should pass `'\\['` to the option.
+
+:::
+
 The left delimiter to use for heading IDs.
 
 #### `rightDelimiter`
 
 > Default: `'}'`
+
+::: warning
+
+Please note that if you use a custom delimiter, it must be escaped since it is used in a regular expression. For example, if you want to use `']'`, you should pass `'\\]'` to the option.
+
+:::
 
 The right delimiter to use for heading IDs.
 


### PR DESCRIPTION
This pull request introduces a new ESLint rule to enforce the use of heading IDs in markdown files and includes various other related updates. The most important changes include the addition of the new rule, its integration into the existing configuration, and the creation of corresponding tests and documentation.

### New Rule Addition:
* [`packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js`](diffhunk://#diff-64161e7614a45746324c8428c938fb2c11f1cf8d9f91d58b096a51ee7e13fb10R1-R158): Added a new rule to enforce the use of heading IDs in markdown files. This rule includes options for customizing delimiters and ignoring specific heading depths.

### Rule Integration:
* [`packages/eslint-plugin-mark/src/configs/all.js`](diffhunk://#diff-dcdf50541cdda584e7b5e20419349e2a8760d86d4d140d12dbd1d97b3084703fR37): Updated the configuration to include the new `mark/heading-id` rule.
* [`packages/eslint-plugin-mark/src/rules/index.js`](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R3-R11): Imported and added the new `heading-id` rule to the list of available rules.
* [`packages/eslint-plugin-mark/src/rules/heading-id/index.js`](diffhunk://#diff-de51b055a4bd30f5c73d4396d81b1a308033d72afd776a17a4d6aecd1115b532R1-R3): Created an index file for the new rule.

### Testing:
* [`packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js`](diffhunk://#diff-41d3fff468d29b876a36603929b8d3fc0d7955966a54462e0d2f941b3d1be571R1-R358): Added comprehensive tests for the new rule, covering various valid and invalid cases.

### Documentation:
* [`website/docs/rules/heading-id.md`](diffhunk://#diff-ed37936a4dbcafb3ae71f55b57e3054eda68340887ef6cb2a566b351f402eabcR1-R148): Added documentation for the new rule, including usage examples, options, and prior art references.

### Other Changes:
* [`.editorconfig`](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR12-R14): Updated to disable trimming trailing whitespace in markdown files.