### PR TITLE
feat(eslint-plugin-mark)!: create `recommended` configuration and make `code-lang-shorthand` rule recommended

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,9 +4,10 @@ import mark from 'eslint-plugin-mark';
 /** @type {import("eslint").Linter.Config[]} */
 export default [
   {
+    name: 'global/ignores',
     ignores: ['**/build/', '**/coverage/', '**/.vitepress/cache/'],
   },
   bananass.configs.js,
   bananass.configs.ts,
-  mark.configs.allGfm,
+  mark.configs.recommendedGfm,
 ];

--- a/packages/eslint-plugin-mark/src/configs/index.js
+++ b/packages/eslint-plugin-mark/src/configs/index.js
@@ -1,4 +1,5 @@
 import all from './all.js';
 import base from './base.js';
+import recommended from './recommended.js';
 
-export { all, base };
+export { all, base, recommended };

--- a/packages/eslint-plugin-mark/src/configs/recommended.js
+++ b/packages/eslint-plugin-mark/src/configs/recommended.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview All configuration.
+ * @fileoverview Recommended configuration.
  */
 
 // --------------------------------------------------------------------------------
@@ -22,22 +22,20 @@ import base from './base.js';
 // --------------------------------------------------------------------------------
 
 /**
- * All configuration.
+ * Recommended configuration.
  *
  * @param {ParserMode} parserMode
  * @return {LinterConfig}
  */
-export default function all(parserMode) {
+export default function recommended(parserMode) {
   return {
     ...base(parserMode),
-    name: `mark/all/${parserMode}`,
+    name: `mark/recommended/${parserMode}`,
     rules: {
       'mark/alt-text': 'error',
       'mark/code-lang-shorthand': 'error',
-      'mark/heading-id': 'warn',
       'mark/no-curly-quotes': 'error',
       'mark/no-double-spaces': 'error',
-      'mark/no-emojis': 'warn',
     },
   };
 }

--- a/packages/eslint-plugin-mark/src/index.js
+++ b/packages/eslint-plugin-mark/src/index.js
@@ -9,7 +9,7 @@
 
 import { createRequire } from 'node:module';
 
-import { all, base } from './configs/index.js';
+import { all, base, recommended } from './configs/index.js';
 import rules from './rules/index.js';
 
 // --------------------------------------------------------------------------------
@@ -46,5 +46,7 @@ export default {
     allGfm: all(gfm),
     baseCommonmark: base(commonmark),
     baseGfm: base(gfm),
+    recommendedCommonmark: recommended(commonmark),
+    recommendedGfm: recommended(gfm),
   },
 };

--- a/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js
+++ b/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js
@@ -112,7 +112,7 @@ export default {
     docs: {
       // @ts-expect-error -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
       name: ruleName,
-      recommended: false,
+      recommended: true,
       description: 'Enforce the use of shorthand for code block language identifiers',
       url: getRuleDocsUrl(ruleName),
     },


### PR DESCRIPTION
This pull request includes several changes to the `eslint-plugin-mark` package, mainly focusing on adding a recommended configuration and updating rule severity levels. The most important changes include adding a new `recommended` configuration, modifying the severity of the `code-lang-shorthand` rule, and updating the `index.js` and `eslint.config.mjs` files to include the new configuration.

### Addition of recommended configuration:

* [`packages/eslint-plugin-mark/src/configs/recommended.js`](diffhunk://#diff-5c2e62dd777b6828656ee264af3302d295f3768516f0cf7dfdbaa939848a0c01R1-R41): Added a new recommended configuration for the `eslint-plugin-mark` package.
* [`packages/eslint-plugin-mark/src/configs/index.js`](diffhunk://#diff-b203cdc09e7b9c5b3872303a75b6a7d4570e43a16311e2f9c3484e18b15247f9R3-R5): Imported and exported the new `recommended` configuration.

### Rule severity updates:

* [`packages/eslint-plugin-mark/src/configs/all.js`](diffhunk://#diff-dcdf50541cdda584e7b5e20419349e2a8760d86d4d140d12dbd1d97b3084703fL36-R36): Changed the severity of the `mark/code-lang-shorthand` rule from `warn` to `error`.
* [`packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js`](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bL115-R115): Set the `recommended` field to `true` for the `mark/code-lang-shorthand` rule.

### Configuration updates:

* [`packages/eslint-plugin-mark/src/index.js`](diffhunk://#diff-70f2388a14811bff072b178c7cfb31ba7a827976b08cc805892d9175b97e2277L12-R12): Updated the export to include the new `recommended` configuration and added the `recommendedCommonmark` and `recommendedGfm` configurations. [[1]](diffhunk://#diff-70f2388a14811bff072b178c7cfb31ba7a827976b08cc805892d9175b97e2277L12-R12) [[2]](diffhunk://#diff-70f2388a14811bff072b178c7cfb31ba7a827976b08cc805892d9175b97e2277R49-R50)
* [`eslint.config.mjs`](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R7-R12): Changed the `mark` configuration from `allGfm` to `recommendedGfm` and added a new `name` field to the configuration object.