### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.0` to `v0.1.0-canary.1` (`prerelease`)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-canary.0"
+  "version": "0.1.0-canary.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-plugin-mark",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "workspaces": [
         ".",
         "packages/*",
@@ -20,7 +20,7 @@
         "editorconfig-checker": "^6.0.0",
         "eslint": "^9.23.0",
         "eslint-config-bananass": "^0.0.6",
-        "eslint-plugin-mark": "^0.1.0-canary.0",
+        "eslint-plugin-mark": "^0.1.0-canary.1",
         "husky": "^9.1.5",
         "lerna": "8.1.9",
         "lint-staged": "^15.5.0",
@@ -20337,7 +20337,7 @@
       }
     },
     "packages/eslint-plugin-mark": {
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^6.3.0",
@@ -20368,12 +20368,12 @@
       "license": "MIT"
     },
     "website": {
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.1",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
         "@shikijs/transformers": "^3.2.1",
         "bananass-utils-vitepress": "^0.0.0",
-        "eslint-plugin-mark": "^0.1.0-canary.0",
+        "eslint-plugin-mark": "^0.1.0-canary.1",
         "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "vitepress": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": ">=20.18.0"
@@ -42,7 +42,7 @@
     "editorconfig-checker": "^6.0.0",
     "eslint": "^9.23.0",
     "eslint-config-bananass": "^0.0.6",
-    "eslint-plugin-mark": "^0.1.0-canary.0",
+    "eslint-plugin-mark": "^0.1.0-canary.1",
     "husky": "^9.1.5",
     "lerna": "8.1.9",
     "lint-staged": "^15.5.0",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mark",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "0.1.0-canary.0",
+  "version": "0.1.0-canary.1",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -12,7 +12,7 @@
     "@codecov/vite-plugin": "^1.9.0",
     "@shikijs/transformers": "^3.2.1",
     "bananass-utils-vitepress": "^0.0.0",
-    "eslint-plugin-mark": "^0.1.0-canary.0",
+    "eslint-plugin-mark": "^0.1.0-canary.1",
     "is-interactive": "^2.0.0",
     "markdown-it-footnote": "^4.0.0",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.1`

New release of `lumirlumir/npm-eslint-plugin-mark` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.0` to `v0.1.0-canary.1` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-eslint-plugin-mark/actions/runs/14145204154) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-plugin-mark` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | 1dca4b2       |
| Old Version | `v0.1.0-canary.0`  |
| New Version | `v0.1.0-canary.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* feat(eslint-plugin-mark)!: create `recommended` configuration and make `code-lang-shorthand` rule recommended by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/37
### :sparkles: Features
* feat(eslint-plugin-mark): add `multipleSpaces` option to `no-double-spaces` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/25
* feat(eslint-plugin-mark): add options to `no-curly-quotes` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/29
* feat(eslint-plugin-mark): create `alt-text` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/31
* feat(eslint-plugin-mark): create `no-emojis` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/33
* feat(eslint-plugin-mark): create `heading-id` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/36
### :toolbox: Chores
* chore(*): fix lerna version to `v8.1.9` (`v8.2.1` caused error) by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/20
* chore(website): add support for code block transformers by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/27
* chore(*): update prettier commands to include `--ignore-unknown` option by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/34
### :memo: Documentation
* docs(website): update documentation for `code-lang-shorthand` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/30
### :recycle: Code Refactoring
* refactor(eslint-plugin-mark): create `getRuleDocsUrl` helper function by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/26
### :arrow_up: Dependency Updates
* chore(deps-dev): bump @types/node from 22.13.10 to 22.13.11 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/21
* chore(deps-dev): bump @types/node from 22.13.11 to 22.13.13 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/28
* chore(deps-dev): bump eslint from 9.22.0 to 9.23.0 and update `@ts-*` directives accordingly by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/22
* chore(deps-dev): update vitepress-plugin-group-icons requirement from ^1.3.7 to ^1.3.8 in /website by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/32
* chore(deps-dev): bump @types/node from 22.13.13 to 22.13.14 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/35


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-plugin-mark/compare/v0.1.0-canary.0...v0.1.0-canary.1