### PR TITLE
refactor(eslint-plugin-mark): remove `name` property from `meta.docs`

### DIFF
--- a/packages/eslint-plugin-mark/src/rules/alt-text/alt-text.js
+++ b/packages/eslint-plugin-mark/src/rules/alt-text/alt-text.js
@@ -8,7 +8,7 @@
 // --------------------------------------------------------------------------------
 
 import * as cheerio from 'cheerio';
-import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
+import { getRuleDocsUrl } from '../../core/helpers/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -22,12 +22,6 @@ import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
  */
 
 // --------------------------------------------------------------------------------
-// Helpers
-// --------------------------------------------------------------------------------
-
-const ruleName = getFileName(import.meta.url);
-
-// --------------------------------------------------------------------------------
 // Rule Definition
 // --------------------------------------------------------------------------------
 
@@ -37,11 +31,9 @@ export default {
     type: 'problem',
 
     docs: {
-      // @ts-expect-error -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
-      name: ruleName,
       recommended: true,
       description: 'Enforce the use of alternative text for images',
-      url: getRuleDocsUrl(ruleName),
+      url: getRuleDocsUrl('alt-text'),
     },
 
     messages: {

--- a/packages/eslint-plugin-mark/src/rules/alt-text/alt-text.test.js
+++ b/packages/eslint-plugin-mark/src/rules/alt-text/alt-text.test.js
@@ -9,14 +9,16 @@
 
 import { test } from 'node:test';
 
+import { getFileName } from '../../core/helpers/index.js';
 import { ruleTesterCommonmark, ruleTesterGfm } from '../../core/rule-tester/index.js';
+
 import rule from './alt-text.js';
 
 // --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
 
-const { name } = rule.meta.docs;
+const name = getFileName(import.meta.url);
 const altText = 'altText';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js
+++ b/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js
@@ -10,7 +10,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
+import { getRuleDocsUrl } from '../../core/helpers/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -24,8 +24,6 @@ import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
 // --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
-
-const ruleName = getFileName(import.meta.url);
 
 /** @type {Record<string, string>} */
 const langShorthandMap = Object.freeze({
@@ -110,11 +108,9 @@ export default {
     type: 'problem',
 
     docs: {
-      // @ts-expect-error -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
-      name: ruleName,
       recommended: true,
       description: 'Enforce the use of shorthand for code block language identifiers',
-      url: getRuleDocsUrl(ruleName),
+      url: getRuleDocsUrl('code-lang-shorthand'),
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.test.js
+++ b/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.test.js
@@ -9,14 +9,16 @@
 
 import { test } from 'node:test';
 
+import { getFileName } from '../../core/helpers/index.js';
 import { ruleTesterCommonmark, ruleTesterGfm } from '../../core/rule-tester/index.js';
+
 import rule from './code-lang-shorthand.js';
 
 // --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
 
-const { name } = rule.meta.docs;
+const name = getFileName(import.meta.url);
 const codeLangShorthand = 'codeLangShorthand';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
+import { getRuleDocsUrl } from '../../core/helpers/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -19,12 +19,6 @@ import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
  */
 
 // --------------------------------------------------------------------------------
-// Helpers
-// --------------------------------------------------------------------------------
-
-const ruleName = getFileName(import.meta.url);
-
-// --------------------------------------------------------------------------------
 // Rule Definition
 // --------------------------------------------------------------------------------
 
@@ -34,11 +28,9 @@ export default {
     type: 'problem',
 
     docs: {
-      // @ts-expect-error -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
-      name: ruleName,
       recommended: false,
       description: 'Enforce the use of heading IDs',
-      url: getRuleDocsUrl(ruleName),
+      url: getRuleDocsUrl('heading-id'),
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js
@@ -9,14 +9,16 @@
 
 import { test } from 'node:test';
 
+import { getFileName } from '../../core/helpers/index.js';
 import { ruleTesterCommonmark, ruleTesterGfm } from '../../core/rule-tester/index.js';
+
 import rule from './heading-id.js';
 
 // --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
 
-const { name } = rule.meta.docs;
+const name = getFileName(import.meta.url);
 const headingIdAlways = 'headingIdAlways';
 const headingIdNever = 'headingIdNever';
 

--- a/packages/eslint-plugin-mark/src/rules/index.js
+++ b/packages/eslint-plugin-mark/src/rules/index.js
@@ -1,3 +1,5 @@
+/* eslint sort-imports: 'error', sort-keys: 'error' */
+
 import altText from './alt-text/index.js';
 import codeLangShorthand from './code-lang-shorthand/index.js';
 import headingId from './heading-id/index.js';
@@ -5,15 +7,11 @@ import noCurlyQuotes from './no-curly-quotes/index.js';
 import noDoubleSpaces from './no-double-spaces/index.js';
 import noEmojis from './no-emojis/index.js';
 
-export default [
-  altText,
-  codeLangShorthand,
-  headingId,
-  noCurlyQuotes,
-  noDoubleSpaces,
-  noEmojis,
-].reduce((rulesObject, rule) => {
-  // @ts-expect-error -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
-  rulesObject[rule.meta.docs.name] = rule;
-  return rulesObject;
-}, {});
+export default {
+  'alt-text': altText,
+  'code-lang-shorthand': codeLangShorthand,
+  'heading-id': headingId,
+  'no-curly-quotes': noCurlyQuotes,
+  'no-double-spaces': noDoubleSpaces,
+  'no-emojis': noEmojis,
+};

--- a/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js
+++ b/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js
@@ -8,7 +8,7 @@
 // --------------------------------------------------------------------------------
 
 import { textHandler } from '../../core/ast/index.js';
-import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
+import { getRuleDocsUrl } from '../../core/helpers/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -22,8 +22,6 @@ import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
 // --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
-
-const ruleName = getFileName(import.meta.url);
 
 const leftDoubleQuotationMark = '\u201C'; // `“`
 const rightDoubleQuotationMark = '\u201D'; // `”`
@@ -42,11 +40,9 @@ export default {
     type: 'problem',
 
     docs: {
-      // @ts-expect-error -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
-      name: ruleName,
       recommended: true,
       description: 'Disallow curly quotes(`“`, `”`, `‘` or `’`) in text',
-      url: getRuleDocsUrl(ruleName),
+      url: getRuleDocsUrl('no-curly-quotes'),
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.test.js
+++ b/packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.test.js
@@ -9,14 +9,16 @@
 
 import { test } from 'node:test';
 
+import { getFileName } from '../../core/helpers/index.js';
 import { ruleTesterCommonmark, ruleTesterGfm } from '../../core/rule-tester/index.js';
+
 import rule from './no-curly-quotes.js';
 
 // --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
 
-const { name } = rule.meta.docs;
+const name = getFileName(import.meta.url);
 const noCurlyQuotes = 'noCurlyQuotes';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-plugin-mark/src/rules/no-double-spaces/no-double-spaces.js
+++ b/packages/eslint-plugin-mark/src/rules/no-double-spaces/no-double-spaces.js
@@ -8,7 +8,7 @@
 // --------------------------------------------------------------------------------
 
 import { textHandler } from '../../core/ast/index.js';
-import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
+import { getRuleDocsUrl } from '../../core/helpers/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -22,8 +22,6 @@ import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
 // --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
-
-const ruleName = getFileName(import.meta.url);
 
 const doubleSpacesRegex = /(?<! ) {2}(?! )/g; // Exactly two spaces. No more, no less.
 const multipleSpacesRegex = /(?<! ) {2,}(?! )/g; // More than two spaces.
@@ -40,12 +38,10 @@ export default {
     type: 'problem',
 
     docs: {
-      // @ts-expect-error -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
-      name: ruleName,
       recommended: true,
       description:
         'Disallow double or multiple consecutive spaces in text, except for leading and trailing spaces',
-      url: getRuleDocsUrl(ruleName),
+      url: getRuleDocsUrl('no-double-spaces'),
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin-mark/src/rules/no-double-spaces/no-double-spaces.test.js
+++ b/packages/eslint-plugin-mark/src/rules/no-double-spaces/no-double-spaces.test.js
@@ -9,14 +9,16 @@
 
 import { test } from 'node:test';
 
+import { getFileName } from '../../core/helpers/index.js';
 import { ruleTesterCommonmark, ruleTesterGfm } from '../../core/rule-tester/index.js';
+
 import rule from './no-double-spaces.js';
 
 // --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
 
-const { name } = rule.meta.docs;
+const name = getFileName(import.meta.url);
 const noDoubleSpaces = 'noDoubleSpaces';
 const noMultipleSpaces = 'noMultipleSpaces';
 

--- a/packages/eslint-plugin-mark/src/rules/no-emojis/no-emojis.js
+++ b/packages/eslint-plugin-mark/src/rules/no-emojis/no-emojis.js
@@ -10,7 +10,7 @@
 import emojiRegex from 'emoji-regex';
 
 import { textHandler } from '../../core/ast/index.js';
-import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
+import { getRuleDocsUrl } from '../../core/helpers/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -22,12 +22,6 @@ import { getFileName, getRuleDocsUrl } from '../../core/helpers/index.js';
  */
 
 // --------------------------------------------------------------------------------
-// Helpers
-// --------------------------------------------------------------------------------
-
-const ruleName = getFileName(import.meta.url);
-
-// --------------------------------------------------------------------------------
 // Rule Definition
 // --------------------------------------------------------------------------------
 
@@ -37,11 +31,9 @@ export default {
     type: 'problem',
 
     docs: {
-      // @ts-expect-error -- TODO: https://github.com/eslint/eslint/issues/19521, https://github.com/eslint/eslint/issues/19523
-      name: ruleName,
       recommended: false,
       description: 'Disallow emojis in text',
-      url: getRuleDocsUrl(ruleName),
+      url: getRuleDocsUrl('no-emojis'),
     },
 
     messages: {

--- a/packages/eslint-plugin-mark/src/rules/no-emojis/no-emojis.test.js
+++ b/packages/eslint-plugin-mark/src/rules/no-emojis/no-emojis.test.js
@@ -9,14 +9,16 @@
 
 import { test } from 'node:test';
 
+import { getFileName } from '../../core/helpers/index.js';
 import { ruleTesterCommonmark, ruleTesterGfm } from '../../core/rule-tester/index.js';
+
 import rule from './no-emojis.js';
 
 // --------------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------------
 
-const { name } = rule.meta.docs;
+const name = getFileName(import.meta.url);
 const noEmojis = 'noEmojis';
 
 // --------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request includes several changes to the `eslint-plugin-mark` package, primarily focused on removing the use of the `getFileName` helper function and simplifying the rule definitions by directly specifying rule names. Additionally, it includes an update to the `index.js` file to improve import and key sorting.

### Removal of `getFileName` usage:
* [`packages/eslint-plugin-mark/src/rules/alt-text/alt-text.js`](diffhunk://#diff-6560944db191e902d3ac04b45b164f66c5bd84703cfc914c50c75fc942048c9fL11-R11): Removed the `getFileName` import and usage, and directly specified the rule name in the `getRuleDocsUrl` function. [[1]](diffhunk://#diff-6560944db191e902d3ac04b45b164f66c5bd84703cfc914c50c75fc942048c9fL11-R11) [[2]](diffhunk://#diff-6560944db191e902d3ac04b45b164f66c5bd84703cfc914c50c75fc942048c9fL24-L29) [[3]](diffhunk://#diff-6560944db191e902d3ac04b45b164f66c5bd84703cfc914c50c75fc942048c9fL40-R36)
* [`packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js`](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bL13-R13): Removed the `getFileName` import and usage, and directly specified the rule name in the `getRuleDocsUrl` function. [[1]](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bL13-R13) [[2]](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bL28-L29) [[3]](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bL113-R113)
* [`packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js`](diffhunk://#diff-64161e7614a45746324c8428c938fb2c11f1cf8d9f91d58b096a51ee7e13fb10L10-R10): Removed the `getFileName` import and usage, and directly specified the rule name in the `getRuleDocsUrl` function. [[1]](diffhunk://#diff-64161e7614a45746324c8428c938fb2c11f1cf8d9f91d58b096a51ee7e13fb10L10-R10) [[2]](diffhunk://#diff-64161e7614a45746324c8428c938fb2c11f1cf8d9f91d58b096a51ee7e13fb10L21-L26) [[3]](diffhunk://#diff-64161e7614a45746324c8428c938fb2c11f1cf8d9f91d58b096a51ee7e13fb10L37-R33)
* [`packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.js`](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L11-R11): Removed the `getFileName` import and usage, and directly specified the rule name in the `getRuleDocsUrl` function. [[1]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L11-R11) [[2]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L26-L27) [[3]](diffhunk://#diff-b82eee9dc72bc6f57aa3c74b30280bdf00d239ceac2a9e5f8ac0c506c3fc9a58L45-R45)
* [`packages/eslint-plugin-mark/src/rules/no-double-spaces/no-double-spaces.js`](diffhunk://#diff-45b4725c516e3cb4cdf9c2d79558ef2e4dec22be6620f5ad2590f7d2fba7c634L11-R11): Removed the `getFileName` import and usage, and directly specified the rule name in the `getRuleDocsUrl` function. [[1]](diffhunk://#diff-45b4725c516e3cb4cdf9c2d79558ef2e4dec22be6620f5ad2590f7d2fba7c634L11-R11) [[2]](diffhunk://#diff-45b4725c516e3cb4cdf9c2d79558ef2e4dec22be6620f5ad2590f7d2fba7c634L26-L27) [[3]](diffhunk://#diff-45b4725c516e3cb4cdf9c2d79558ef2e4dec22be6620f5ad2590f7d2fba7c634L43-R44)
* [`packages/eslint-plugin-mark/src/rules/no-emojis/no-emojis.js`](diffhunk://#diff-4634fc4a56813f283caa4a6660f16cfcb2613857b3f56ab756d132a86d9e80b5L13-R13): Removed the `getFileName` import and usage, and directly specified the rule name in the `getRuleDocsUrl` function. [[1]](diffhunk://#diff-4634fc4a56813f283caa4a6660f16cfcb2613857b3f56ab756d132a86d9e80b5L13-R13) [[2]](diffhunk://#diff-4634fc4a56813f283caa4a6660f16cfcb2613857b3f56ab756d132a86d9e80b5L24-L29) [[3]](diffhunk://#diff-4634fc4a56813f283caa4a6660f16cfcb2613857b3f56ab756d132a86d9e80b5L40-R36)

### Test file updates:
* [`packages/eslint-plugin-mark/src/rules/alt-text/alt-text.test.js`](diffhunk://#diff-4bf5c4182b3bd7fbce9deac2a8aaa8d943d3eff131d6427495172d55c4f55106R12-R21): Added import and usage of `getFileName` to define the rule name.
* [`packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.test.js`](diffhunk://#diff-18f9af089d57586ea0832f9a98f452a2e931db45929f9c10bc54a700ed9411a0R12-R21): Added import and usage of `getFileName` to define the rule name.
* [`packages/eslint-plugin-mark/src/rules/heading-id/heading-id.test.js`](diffhunk://#diff-41d3fff468d29b876a36603929b8d3fc0d7955966a54462e0d2f941b3d1be571R12-R21): Added import and usage of `getFileName` to define the rule name.
* [`packages/eslint-plugin-mark/src/rules/no-curly-quotes/no-curly-quotes.test.js`](diffhunk://#diff-a79b567f8645e8f78ea7976815555f9faa02f925c75631e24b869c97e4eac901R12-R21): Added import and usage of `getFileName` to define the rule name.
* [`packages/eslint-plugin-mark/src/rules/no-double-spaces/no-double-spaces.test.js`](diffhunk://#diff-506a554c985b6e6f7d7a97d8d0707297dbf67520cb9d0d4af28d2d7ed3763f60R12-R21): Added import and usage of `getFileName` to define the rule name.
* [`packages/eslint-plugin-mark/src/rules/no-emojis/no-emojis.test.js`](diffhunk://#diff-43b22aa89c2f888853285e2b8f4908c6ed38b2b5fd15c25f6cc4ee63a2057d6eR12-R21): Added import and usage of `getFileName` to define the rule name.

### Codebase simplification:
* [`packages/eslint-plugin-mark/src/rules/index.js`](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R1-R17): Updated the export structure to use an object with rule names as keys, and added ESLint rules for sorting imports and keys.