### PR TITLE
test(*): create integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18188,6 +18188,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/tests-integration": {
+      "resolved": "tests/integration",
+      "link": true
+    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -20366,6 +20370,13 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "license": "MIT"
+    },
+    "tests/integration": {
+      "name": "tests-integration",
+      "version": "0.1.0-canary.1",
+      "devDependencies": {
+        "eslint-plugin-mark": "^0.1.0-canary.1"
+      }
     },
     "website": {
       "version": "0.1.0-canary.1",

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "name": "tests-integration",
+  "version": "0.1.0-canary.1",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "eslint-plugin-mark": "^0.1.0-canary.1"
+  }
+}

--- a/tests/integration/rules-meta.test.js
+++ b/tests/integration/rules-meta.test.js
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Tests for rule's `meta` properties.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { describe, it } from 'node:test';
+import { doesNotMatch, match, ok } from 'node:assert';
+
+import mark from 'eslint-plugin-mark';
+
+// ---------------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------------
+
+const { rules } = mark;
+
+// ---------------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------------
+
+describe('rules-meta', () => {
+  it('`meta` should exist', () => {
+    Object.values(rules).forEach(rule => {
+      const { meta } = rule;
+
+      ok(meta);
+    });
+  });
+
+  it('`meta.type` should exist', () => {
+    Object.values(rules).forEach(rule => {
+      const { type } = rule.meta;
+
+      ok(type);
+    });
+  });
+
+  it('`meta.docs` should exist', () => {
+    Object.values(rules).forEach(rule => {
+      const { docs } = rule.meta;
+
+      ok(docs);
+    });
+  });
+
+  it('`meta.docs.description` should exist and should not end with a period', () => {
+    Object.values(rules).forEach(rule => {
+      const { description } = rule.meta.docs;
+
+      ok(description);
+      doesNotMatch(description, /\.$/);
+    });
+  });
+
+  it('`meta.docs.url` should exist and should end with the rule name defined in `index.js`', () => {
+    Object.entries(rules).forEach(([ruleName, rule]) => {
+      const { url } = rule.meta.docs;
+
+      ok(url);
+      match(rule.meta.docs.url, new RegExp(`${ruleName}$`));
+    });
+  });
+
+  it('`meta.messages` should exist', () => {
+    Object.values(rules).forEach(rule => {
+      const { messages } = rule.meta;
+
+      ok(messages);
+    });
+  });
+
+  it('`meta.language` should exist and should be `markdown`', () => {
+    Object.values(rules).forEach(rule => {
+      const { language } = rule.meta;
+
+      ok(language);
+      match(language, /^markdown$/);
+    });
+  });
+
+  it("`meta.dialects` should exist and should be `'commonmark'` or `'gfm'`", () => {
+    Object.values(rules).forEach(rule => {
+      const { dialects } = rule.meta;
+
+      ok(dialects);
+      dialects.forEach(dialect => {
+        match(dialect, /^(?:commonmark|gfm)$/);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new integration testing setup for the project. The most important changes include the addition of a new `package.json` file for the integration tests and a comprehensive set of tests for validating the `meta` properties of ESLint rules.

Integration testing setup:

* [`tests/integration/package.json`](diffhunk://#diff-c00d3342bd6ea1035b41a632bc4aa66fb142773d3ad70d34586e29976cd0f884R1-R12): Added a new `package.json` file to define the integration test setup, including scripts and development dependencies.

Validation of `meta` properties:

* [`tests/integration/rules-meta.test.js`](diffhunk://#diff-20c2bcc314cb2638c805dba2d92cf16d3d6163bbd2dd05c7d899c8f1e9ecec06R1-R94): Added a new test file to validate the `meta` properties of ESLint rules, ensuring they meet specific criteria such as existence and correct formatting.