### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.1` to `v0.1.0-canary.2` (`prerelease`)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-canary.1"
+  "version": "0.1.0-canary.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.1",
+  "version": "0.1.0-canary.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-plugin-mark",
-      "version": "0.1.0-canary.1",
+      "version": "0.1.0-canary.2",
       "workspaces": [
         ".",
         "packages/*",
@@ -20,7 +20,7 @@
         "editorconfig-checker": "^6.0.0",
         "eslint": "^9.23.0",
         "eslint-config-bananass": "^0.0.7",
-        "eslint-plugin-mark": "^0.1.0-canary.1",
+        "eslint-plugin-mark": "^0.1.0-canary.2",
         "husky": "^9.1.5",
         "lerna": "8.1.9",
         "lint-staged": "^15.5.0",
@@ -20341,7 +20341,7 @@
       }
     },
     "packages/eslint-plugin-mark": {
-      "version": "0.1.0-canary.1",
+      "version": "0.1.0-canary.2",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^6.3.0",
@@ -20373,18 +20373,18 @@
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.1.0-canary.1",
+      "version": "0.1.0-canary.2",
       "devDependencies": {
-        "eslint-plugin-mark": "^0.1.0-canary.1"
+        "eslint-plugin-mark": "^0.1.0-canary.2"
       }
     },
     "website": {
-      "version": "0.1.0-canary.1",
+      "version": "0.1.0-canary.2",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
         "@shikijs/transformers": "^3.2.1",
         "bananass-utils-vitepress": "^0.0.0",
-        "eslint-plugin-mark": "^0.1.0-canary.1",
+        "eslint-plugin-mark": "^0.1.0-canary.2",
         "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "vitepress": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.1",
+  "version": "0.1.0-canary.2",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": ">=20.18.0"
@@ -42,7 +42,7 @@
     "editorconfig-checker": "^6.0.0",
     "eslint": "^9.23.0",
     "eslint-config-bananass": "^0.0.7",
-    "eslint-plugin-mark": "^0.1.0-canary.1",
+    "eslint-plugin-mark": "^0.1.0-canary.2",
     "husky": "^9.1.5",
     "lerna": "8.1.9",
     "lint-staged": "^15.5.0",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mark",
-  "version": "0.1.0-canary.1",
+  "version": "0.1.0-canary.2",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.1.0-canary.1",
+  "version": "0.1.0-canary.2",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "eslint-plugin-mark": "^0.1.0-canary.1"
+    "eslint-plugin-mark": "^0.1.0-canary.2"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "0.1.0-canary.1",
+  "version": "0.1.0-canary.2",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -12,7 +12,7 @@
     "@codecov/vite-plugin": "^1.9.0",
     "@shikijs/transformers": "^3.2.1",
     "bananass-utils-vitepress": "^0.0.0",
-    "eslint-plugin-mark": "^0.1.0-canary.1",
+    "eslint-plugin-mark": "^0.1.0-canary.2",
     "is-interactive": "^2.0.0",
     "markdown-it-footnote": "^4.0.0",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.2`

New release of `lumirlumir/npm-eslint-plugin-mark` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.1` to `v0.1.0-canary.2` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-eslint-plugin-mark/actions/runs/14326829294) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-plugin-mark` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | 3f084cf       |
| Old Version | `v0.1.0-canary.1`  |
| New Version | `v0.1.0-canary.2`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* chore(*)!: rename rule names from plural to singular by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/49
### :sparkles: Features
* feat(eslint-plugin-mark): create `no-irregular-whitespace` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/48
* feat(eslint-plugin-mark): create `no-git-conflict-marker` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/55
### :toolbox: Chores
* chore(sync-server): update `.gitattributes` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/39
* chore(*): rename root level configs to `.cjs` or `.mjs` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/43
### :memo: Documentation
* docs(*): add badges to `README.md` and update `no-curly-quotes.md` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/45
### :recycle: Code Refactoring
* refactor(eslint-plugin-mark): remove `name` property from `meta.docs` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/46
* refactor(eslint-plugin-mark): minor tweaks and cleanup by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/53
* refactor(eslint-plugin-mark): create `ignoredPositions` ast helper class by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/54
### :test_tube: Tests
* test(*): create integration tests by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/47
### :arrow_up: Dependency Updates
* chore(deps-dev): bump textlint from 14.5.0 to 14.6.0 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/40
* chore(deps-dev): bump @types/node from 22.13.14 to 22.13.17 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/41
* chore(deps-dev): bump @types/node from 22.13.17 to 22.14.0 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/42
* chore(deps-dev): bump eslint-config-bananass from 0.0.6 to 0.0.7 in the bananass group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/44
* chore(deps-dev): bump typescript from 5.8.2 to 5.8.3 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/50


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-plugin-mark/compare/v0.1.0-canary.1...v0.1.0-canary.2