### PR TITLE
feat(eslint-plugin-mark): create `no-bold-paragraph` rule

### DIFF
--- a/packages/eslint-plugin-mark/src/configs/all.js
+++ b/packages/eslint-plugin-mark/src/configs/all.js
@@ -35,6 +35,7 @@ export default function all(parserMode) {
       'mark/alt-text': 'error',
       'mark/code-lang-shorthand': 'error',
       'mark/heading-id': 'warn',
+      'mark/no-bold-paragraph': 'error',
       'mark/no-curly-quote': 'error',
       'mark/no-double-space': 'error',
       'mark/no-emoji': 'warn',

--- a/packages/eslint-plugin-mark/src/configs/recommended.js
+++ b/packages/eslint-plugin-mark/src/configs/recommended.js
@@ -34,6 +34,7 @@ export default function recommended(parserMode) {
     rules: {
       'mark/alt-text': 'error',
       'mark/code-lang-shorthand': 'error',
+      'mark/no-bold-paragraph': 'error',
       'mark/no-curly-quote': 'error',
       'mark/no-double-space': 'error',
       'mark/no-git-conflict-marker': 'error',

--- a/packages/eslint-plugin-mark/src/rules/index.js
+++ b/packages/eslint-plugin-mark/src/rules/index.js
@@ -3,6 +3,7 @@
 import altText from './alt-text/index.js';
 import codeLangShorthand from './code-lang-shorthand/index.js';
 import headingId from './heading-id/index.js';
+import noBoldParagraph from './no-bold-paragraph/index.js';
 import noCurlyQuote from './no-curly-quote/index.js';
 import noDoubleSpace from './no-double-space/index.js';
 import noEmoji from './no-emoji/index.js';
@@ -13,6 +14,7 @@ export default {
   'alt-text': altText,
   'code-lang-shorthand': codeLangShorthand,
   'heading-id': headingId,
+  'no-bold-paragraph': noBoldParagraph,
   'no-curly-quote': noCurlyQuote,
   'no-double-space': noDoubleSpace,
   'no-emoji': noEmoji,

--- a/packages/eslint-plugin-mark/src/rules/no-bold-paragraph/.gitkeep
+++ b/packages/eslint-plugin-mark/src/rules/no-bold-paragraph/.gitkeep
@@ -1,1 +1,0 @@
-https://github.com/aborazmeh/textlint-rule-no-bold-paragraph

--- a/packages/eslint-plugin-mark/src/rules/no-bold-paragraph/index.js
+++ b/packages/eslint-plugin-mark/src/rules/no-bold-paragraph/index.js
@@ -1,0 +1,3 @@
+import noBoldParagraph from './no-bold-paragraph.js';
+
+export default noBoldParagraph;

--- a/packages/eslint-plugin-mark/src/rules/no-bold-paragraph/no-bold-paragraph.js
+++ b/packages/eslint-plugin-mark/src/rules/no-bold-paragraph/no-bold-paragraph.js
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview Rule to disallow using fully bolded paragraphs as headings.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { getRuleDocsUrl } from '../../core/helpers/index.js';
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {import("@eslint/markdown").RuleModule} RuleModule
+ * @typedef {import("mdast").Strong} Strong
+ */
+
+// --------------------------------------------------------------------------------
+// Rule Definition
+// --------------------------------------------------------------------------------
+
+/** @type {RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      recommended: true,
+      description: 'Disallow using fully bolded paragraphs as headings',
+      url: getRuleDocsUrl('no-bold-paragraph'),
+    },
+
+    messages: {
+      noBoldParagraph:
+        'Fully bolded paragraphs should not be used as headings. Please use a heading instead.',
+    },
+
+    language: 'markdown',
+
+    dialects: ['commonmark', 'gfm'],
+  },
+
+  create(context) {
+    return {
+      /** @param {Strong} node */
+      strong(node) {
+        // @ts-expect-error -- TODO
+        const parentNode = context.sourceCode.getParent(node);
+        // @ts-expect-error -- TODO
+        const ancestorNode = context.sourceCode.getParent(parentNode);
+
+        if (
+          parentNode.type === 'paragraph' &&
+          ancestorNode.type !== 'listItem' &&
+          parentNode.position.start.line === parentNode.position.end.line && // Should be a single line.
+          parentNode.position.start.offset === node.position.start.offset && // Should have the same start offset.
+          parentNode.position.end.offset === node.position.end.offset // Should have the same end offset.
+        ) {
+          context.report({
+            // @ts-expect-error -- TODO
+            node,
+
+            messageId: 'noBoldParagraph',
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-mark/src/rules/no-bold-paragraph/no-bold-paragraph.test.js
+++ b/packages/eslint-plugin-mark/src/rules/no-bold-paragraph/no-bold-paragraph.test.js
@@ -1,0 +1,127 @@
+/**
+ * @fileoverview Test for `no-bold-paragraph.js`.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { test } from 'node:test';
+
+import { getFileName } from '../../core/helpers/index.js';
+import { ruleTesterCommonmark, ruleTesterGfm } from '../../core/rule-tester/index.js';
+
+import rule from './no-bold-paragraph.js';
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const name = getFileName(import.meta.url);
+const noBoldParagraph = 'noBoldParagraph';
+
+// --------------------------------------------------------------------------------
+// Testcases
+// --------------------------------------------------------------------------------
+
+const tests = {
+  valid: [
+    // Basic
+    {
+      name: 'Empty',
+      code: '',
+    },
+    {
+      name: 'Empty string',
+      code: '  ',
+    },
+    {
+      name: 'Paragraph without bolded text',
+      code: '#Book\n\nFirst Chapter\n\nContent\n\nSecond Chapter\n\nContent',
+    },
+    {
+      name: 'Paragraph with bolded text and other text',
+      code: '**Hello** World.\n\nHello **World**.',
+    },
+    {
+      name: 'Paragraph with bolded text and other multiline text',
+      code: '**Hello**\nWorld.\n\nHello\n**World**.',
+    },
+    {
+      name: 'Bold with whitespace inside',
+      code: '** Not fully bolded paragraph **',
+    },
+    {
+      name: 'Multiple bold elements comprising entire paragraph',
+      code: '**First part** **second part**',
+    },
+
+    // ListItem
+    {
+      name: 'Bold text in list item',
+      code: '- **List item**\n- __List item__',
+    },
+  ],
+
+  invalid: [
+    // Basic
+    {
+      name: 'Paragraph with fully bolded text',
+      code: '#Book\n\n**First Chapter**\n\nContent\n\n__Second Chapter__\n\nContent',
+      errors: [
+        {
+          messageId: noBoldParagraph,
+          line: 3,
+          column: 1,
+          endLine: 3,
+          endColumn: 18,
+        },
+        {
+          messageId: noBoldParagraph,
+          line: 7,
+          column: 1,
+          endLine: 7,
+          endColumn: 19,
+        },
+      ],
+    },
+    {
+      name: 'Paragraph with fully bolded single character',
+      code: '**X**',
+      errors: [
+        {
+          messageId: noBoldParagraph,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 6,
+        },
+      ],
+    },
+
+    // Blockquote
+    {
+      name: 'Bold text in blockquote',
+      code: '> **Blockquote**',
+      errors: [
+        {
+          messageId: noBoldParagraph,
+          line: 1,
+          column: 3,
+          endLine: 1,
+          endColumn: 17,
+        },
+      ],
+    },
+  ],
+};
+
+// --------------------------------------------------------------------------------
+// Test Runner
+// --------------------------------------------------------------------------------
+
+test(name, () => {
+  ruleTesterCommonmark.run(name, rule, tests);
+  ruleTesterGfm.run(name, rule, tests);
+});

--- a/website/docs/rules/alt-text.md
+++ b/website/docs/rules/alt-text.md
@@ -32,6 +32,8 @@ Or with HTML as:
 <img src="https://example.com/image.jpg" alt="alternative text" />
 ```
 
+## Examples
+
 ### :x: Incorrect {#incorrect}
 
 Examples of **incorrect** code for this rule:

--- a/website/docs/rules/code-lang-shorthand.md
+++ b/website/docs/rules/code-lang-shorthand.md
@@ -11,6 +11,8 @@ Note that the code block language identifiers are **case-insensitive**, meaning 
 
 You can see the full list of [language identifiers shorthand mapping](https://github.com/lumirlumir/npm-eslint-plugin-mark/blob/main/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js#L31-L101) in the source code.
 
+## Examples
+
 ### :x: Incorrect {#incorrect}
 
 Examples of **incorrect** code for this rule:

--- a/website/docs/rules/heading-id.md
+++ b/website/docs/rules/heading-id.md
@@ -9,6 +9,8 @@ Heading IDs are helpful for linking to specific sections within a document and a
 
 When building websites with internationalization in mind, it's recommended to use English words for heading IDs. This is because certain languages may cause issues with URL encoding, leading to characters like `%20` or `%C3%A9` when IDs are encoded, which can make it difficult for people to recognize.
 
+## Examples
+
 ### :x: Incorrect
 
 Examples of **incorrect** code for this rule:

--- a/website/docs/rules/no-bold-paragraph.md
+++ b/website/docs/rules/no-bold-paragraph.md
@@ -1,0 +1,82 @@
+<!-- markdownlint-disable-next-line no-inline-html first-line-h1 -->
+<header v-html="$frontmatter.rule"></header>
+
+## Rule Details
+
+This rule disallows using fully bolded paragraphs as headings. The use of fully bolded paragraphs as headings is a common anti-pattern that reduces document semantics and accessibility. Instead, proper heading elements (`#`, `##`, etc.) should be used.
+
+### Why This Is Important
+
+Using proper headings instead of bolded paragraphs:
+
+- Improves document structure and semantics
+- Enhances accessibility for screen readers
+- Creates proper document outline
+- Makes navigation of the document easier
+
+### What This Rule Checks
+
+This rule identifies paragraphs that:
+
+- Consist entirely of a bold element (`**text**` or `__text__`)
+- Are contained on a single line
+- Are not within list items
+- Have bold markup that spans the entire paragraph content
+
+## Examples
+
+### :x: Incorrect
+
+Examples of **incorrect** code for this rule:
+
+```md /**First Chapter**/ /__Second Chapter__/
+<!-- eslint mark/no-bold-paragraph: "error" -->
+
+# Book
+
+**First Chapter**
+
+Content of the first chapter
+
+__Second Chapter__
+
+Content of the second chapter
+```
+
+### :white_check_mark: Correct
+
+Examples of **correct** code for this rule:
+
+```md
+<!-- eslint mark/no-bold-paragraph: "error" -->
+
+# Book
+
+## First Chapter
+
+Content of the first chapter
+
+## Second Chapter
+
+Content of the second chapter
+
+---
+
+**Bold text** with normal text in the paragraph.
+
+Text with **bold parts** is fine.
+
+- **Bold text in a list item** is allowed.
+```
+
+## Options
+
+No options are available for this rule.
+
+## AST
+
+This rule applies to the [`Strong`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#strong), [`Paragraph`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#paragraph), and [`ListItem`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#listItem) nodes.
+
+## Prior Art
+
+- [textlint-rule-no-bold-paragraph](https://github.com/aborazmeh/textlint-rule-no-bold-paragraph)

--- a/website/docs/rules/no-curly-quote.md
+++ b/website/docs/rules/no-curly-quote.md
@@ -9,6 +9,8 @@ In addition, curly quotes (`“` `\u201C`, `”` `\u201D`, `‘` `\u2018` or `�
 
 By applying this rule, you can prevent unintended curly quotes and keep your code clean and consistent.
 
+## Examples
+
 ### :x: Incorrect {#incorrect}
 
 Examples of **incorrect** code for this rule:

--- a/website/docs/rules/no-double-space.md
+++ b/website/docs/rules/no-double-space.md
@@ -9,6 +9,8 @@ Double spaces within a sentence are usually typos and can be hard to spot. This 
 
 It only checks for **double or multiple consecutive** spaces ***within sentences***. Since **leading** and **trailing** spaces have special meanings in Markdown, this rule does not check for them. **Leading** spaces are used for creating code blocks or indentation, while **trailing** spaces are used to create line breaks.
 
+## Examples
+
 ### :x: Incorrect {#incorrect}
 
 Examples of **incorrect** code for this rule:

--- a/website/docs/rules/no-emoji.md
+++ b/website/docs/rules/no-emoji.md
@@ -11,6 +11,8 @@ For a full list of supported emojis, you can refer to the [Emoji Cheat Sheet](ht
 
 Platforms like [GitHub](https://github.com) and Markdown plugins such as [`remark-emoji`](https://github.com/rhysd/remark-emoji) and [`markdown-it-emoji`](https://github.com/markdown-it/markdown-it-emoji) also support this feature.
 
+## Examples
+
 ### :x: Incorrect {#incorrect}
 
 Examples of **incorrect** code for this rule:

--- a/website/docs/rules/no-git-conflict-marker.md
+++ b/website/docs/rules/no-git-conflict-marker.md
@@ -19,6 +19,8 @@ While other programming languages would typically throw syntax errors when confl
 
 This rule identifies and reports any Git conflict markers in your Markdown files to ensure they are resolved before the content is published or shared.
 
+## Examples
+
 ### :x: Incorrect
 
 Examples of **incorrect** code for this rule:


### PR DESCRIPTION
This pull request introduces a new rule to the `eslint-plugin-mark` package, which disallows using fully bolded paragraphs as headings. It also includes updates to various documentation files to add examples for existing rules.

### New Rule Addition:
* Added `no-bold-paragraph` rule to disallow fully bolded paragraphs as headings. This rule improves document structure, semantics, and accessibility. [[1]](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R6) [[2]](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R17) [[3]](diffhunk://#diff-cb42de3269dd17273b0e96cda1a62ba7ffcee7861c54fbbab48175c645d75642R1-R3) [[4]](diffhunk://#diff-142341221567262737addbdd1ec0463dd2bd78ea8c050e86302251a583a2c3b4R1-R72) [[5]](diffhunk://#diff-79a865aa7a973f7c5e71454204c9a017286eaf8cc697f3d70ee9a2ae0db2a6abR1-R127)

### Configuration Updates:
* Included the `no-bold-paragraph` rule in the `all` and `recommended` configurations. [[1]](diffhunk://#diff-dcdf50541cdda584e7b5e20419349e2a8760d86d4d140d12dbd1d97b3084703fR38) [[2]](diffhunk://#diff-5c2e62dd777b6828656ee264af3302d295f3768516f0cf7dfdbaa939848a0c01R37)

### Documentation Enhancements:
* Updated the documentation for various rules (`alt-text`, `code-lang-shorthand`, `heading-id`, `no-curly-quote`, `no-double-space`, `no-emoji`, `no-git-conflict-marker`) to include example sections. [[1]](diffhunk://#diff-05707a63cf0061d03420be2cfcb93cb508699d7df712e45a57eb6faa2544b93eR35-R36) [[2]](diffhunk://#diff-52fdd05ab9363d42be689337a6ab0913b99f2cc6df446519a1ee7582bf4fc98aR14-R15) [[3]](diffhunk://#diff-ed37936a4dbcafb3ae71f55b57e3054eda68340887ef6cb2a566b351f402eabcR12-R13) [[4]](diffhunk://#diff-c4b304acc8de988c0c4239525163de773df8720e50e624575e5dc8d28a15f02cR12-R13) [[5]](diffhunk://#diff-6790582beb75c723875b6228a12f3f1ace1020ab05b55dcdc7da529f64a937d7R12-R13) [[6]](diffhunk://#diff-628a6aa8eb7ee467b890fa0401343cffe1ace03118b88f2853c7714230ec4b00R14-R15) [[7]](diffhunk://#diff-5e6b1687e0b2cf50aed9dd8bc06805979e4a827b46b4dc3f1c47d33ed2a4e252R22-R23)
* Added a new documentation file for the `no-bold-paragraph` rule, detailing its purpose, importance, checks, examples, and AST nodes.