### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.2` to `v0.1.0-canary.3` (`prerelease`)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-canary.2"
+  "version": "0.1.0-canary.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.2",
+  "version": "0.1.0-canary.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-plugin-mark",
-      "version": "0.1.0-canary.2",
+      "version": "0.1.0-canary.3",
       "workspaces": [
         ".",
         "packages/*",
@@ -20,7 +20,7 @@
         "editorconfig-checker": "^6.0.0",
         "eslint": "^9.23.0",
         "eslint-config-bananass": "^0.0.7",
-        "eslint-plugin-mark": "^0.1.0-canary.2",
+        "eslint-plugin-mark": "^0.1.0-canary.3",
         "husky": "^9.1.5",
         "lerna": "8.1.9",
         "lint-staged": "^15.5.0",
@@ -20341,7 +20341,7 @@
       }
     },
     "packages/eslint-plugin-mark": {
-      "version": "0.1.0-canary.2",
+      "version": "0.1.0-canary.3",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^6.3.0",
@@ -20373,18 +20373,18 @@
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.1.0-canary.2",
+      "version": "0.1.0-canary.3",
       "devDependencies": {
-        "eslint-plugin-mark": "^0.1.0-canary.2"
+        "eslint-plugin-mark": "^0.1.0-canary.3"
       }
     },
     "website": {
-      "version": "0.1.0-canary.2",
+      "version": "0.1.0-canary.3",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
         "@shikijs/transformers": "^3.2.1",
         "bananass-utils-vitepress": "^0.0.0",
-        "eslint-plugin-mark": "^0.1.0-canary.2",
+        "eslint-plugin-mark": "^0.1.0-canary.3",
         "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "vitepress": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.2",
+  "version": "0.1.0-canary.3",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": ">=20.18.0"
@@ -42,7 +42,7 @@
     "editorconfig-checker": "^6.0.0",
     "eslint": "^9.23.0",
     "eslint-config-bananass": "^0.0.7",
-    "eslint-plugin-mark": "^0.1.0-canary.2",
+    "eslint-plugin-mark": "^0.1.0-canary.3",
     "husky": "^9.1.5",
     "lerna": "8.1.9",
     "lint-staged": "^15.5.0",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mark",
-  "version": "0.1.0-canary.2",
+  "version": "0.1.0-canary.3",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.1.0-canary.2",
+  "version": "0.1.0-canary.3",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "eslint-plugin-mark": "^0.1.0-canary.2"
+    "eslint-plugin-mark": "^0.1.0-canary.3"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "0.1.0-canary.2",
+  "version": "0.1.0-canary.3",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -12,7 +12,7 @@
     "@codecov/vite-plugin": "^1.9.0",
     "@shikijs/transformers": "^3.2.1",
     "bananass-utils-vitepress": "^0.0.0",
-    "eslint-plugin-mark": "^0.1.0-canary.2",
+    "eslint-plugin-mark": "^0.1.0-canary.3",
     "is-interactive": "^2.0.0",
     "markdown-it-footnote": "^4.0.0",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.3`

New release of `lumirlumir/npm-eslint-plugin-mark` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.2` to `v0.1.0-canary.3` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-eslint-plugin-mark/actions/runs/14336993471) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-plugin-mark` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | 24493d5       |
| Old Version | `v0.1.0-canary.2`  |
| New Version | `v0.1.0-canary.3`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(eslint-plugin-mark): create `no-bold-paragraph` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/57
* feat(eslint-plugin-mark): create `no-irregular-dash` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/58


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-plugin-mark/compare/v0.1.0-canary.2...v0.1.0-canary.3