### PR TITLE
feat(eslint-plugin-mark): create `no-control-character` rule

### DIFF
--- a/packages/eslint-plugin-mark/src/configs/all.js
+++ b/packages/eslint-plugin-mark/src/configs/all.js
@@ -36,6 +36,7 @@ export default function all(parserMode) {
       'mark/code-lang-shorthand': 'error',
       'mark/heading-id': 'warn',
       'mark/no-bold-paragraph': 'error',
+      'mark/no-control-character': 'error',
       'mark/no-curly-quote': 'error',
       'mark/no-double-space': 'error',
       'mark/no-emoji': 'warn',

--- a/packages/eslint-plugin-mark/src/configs/recommended.js
+++ b/packages/eslint-plugin-mark/src/configs/recommended.js
@@ -35,6 +35,7 @@ export default function recommended(parserMode) {
       'mark/alt-text': 'error',
       'mark/code-lang-shorthand': 'error',
       'mark/no-bold-paragraph': 'error',
+      'mark/no-control-character': 'error',
       'mark/no-curly-quote': 'error',
       'mark/no-double-space': 'error',
       'mark/no-git-conflict-marker': 'error',

--- a/packages/eslint-plugin-mark/src/rules/en-diacritic/.gitkeep
+++ b/packages/eslint-plugin-mark/src/rules/en-diacritic/.gitkeep
@@ -1,1 +1,0 @@
-https://github.com/sapegin/textlint-rule-diacritics

--- a/packages/eslint-plugin-mark/src/rules/index.js
+++ b/packages/eslint-plugin-mark/src/rules/index.js
@@ -4,6 +4,7 @@ import altText from './alt-text/index.js';
 import codeLangShorthand from './code-lang-shorthand/index.js';
 import headingId from './heading-id/index.js';
 import noBoldParagraph from './no-bold-paragraph/index.js';
+import noControlCharacter from './no-control-character/index.js';
 import noCurlyQuote from './no-curly-quote/index.js';
 import noDoubleSpace from './no-double-space/index.js';
 import noEmoji from './no-emoji/index.js';
@@ -16,6 +17,7 @@ export default {
   'code-lang-shorthand': codeLangShorthand,
   'heading-id': headingId,
   'no-bold-paragraph': noBoldParagraph,
+  'no-control-character': noControlCharacter,
   'no-curly-quote': noCurlyQuote,
   'no-double-space': noDoubleSpace,
   'no-emoji': noEmoji,

--- a/packages/eslint-plugin-mark/src/rules/no-control-character/.gitkeep
+++ b/packages/eslint-plugin-mark/src/rules/no-control-character/.gitkeep
@@ -1,2 +1,0 @@
-- <https://github.com/textlint-rule/textlint-rule-no-invalid-control-character>
-- <https://eslint.org/docs/latest/rules/no-control-regex#rule-details>

--- a/packages/eslint-plugin-mark/src/rules/no-control-character/index.js
+++ b/packages/eslint-plugin-mark/src/rules/no-control-character/index.js
@@ -1,0 +1,3 @@
+import noControlCharacter from './no-control-character.js';
+
+export default noControlCharacter;

--- a/packages/eslint-plugin-mark/src/rules/no-control-character/no-control-character.js
+++ b/packages/eslint-plugin-mark/src/rules/no-control-character/no-control-character.js
@@ -1,0 +1,138 @@
+/**
+ * @fileoverview Rule to disallow control character.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+/* eslint-disable no-control-regex -- Needed for rule definition. */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { IgnoredPositions } from '../../core/ast/index.js';
+import { getRuleDocsUrl } from '../../core/helpers/index.js';
+import { ZERO_TO_ONE_BASED_OFFSET } from '../../core/constants.js';
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {import("@eslint/markdown").RuleModule} RuleModule
+ * @typedef {import("mdast").Code} Code
+ * @typedef {import("mdast").InlineCode} InlineCode
+ * @typedef {import("unist").Position} Position
+ */
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const controlCharacterRegex =
+  /[\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u000b\u000c\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008a\u008b\u008c\u008d\u008e\u008f\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f\u202c\u202d\u202e]/gu;
+
+// --------------------------------------------------------------------------------
+// Rule Definition
+// --------------------------------------------------------------------------------
+
+/** @type {RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      recommended: true,
+      description: 'Disallow control character',
+      url: getRuleDocsUrl('no-control-character'),
+    },
+
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          skipCode: {
+            type: 'boolean',
+          },
+          skipInlineCode: {
+            type: 'boolean',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+
+    defaultOptions: [
+      {
+        skipCode: true,
+        skipInlineCode: true,
+      },
+    ],
+
+    messages: {
+      noControlCharacter: 'Control character `{{ controlCharacter }}` is not allowed.',
+    },
+
+    language: 'markdown',
+
+    dialects: ['commonmark', 'gfm'],
+  },
+
+  create(context) {
+    // @ts-expect-error -- TODO
+    const [{ skipCode, skipInlineCode }] = context.options;
+    const { lines } = context.sourceCode;
+
+    const ignoredPositions = new IgnoredPositions();
+
+    return {
+      /** @param {Code} node */
+      code(node) {
+        if (skipCode) ignoredPositions.push(node.position); // Store position information of `Code`.
+      },
+
+      /** @param {InlineCode} node */
+      inlineCode(node) {
+        if (skipInlineCode) ignoredPositions.push(node.position); // Store position information of `InlineCode`.
+      },
+
+      'root:exit': function () {
+        lines.forEach((line, lineIndex) => {
+          const matches = [...line.matchAll(controlCharacterRegex)];
+
+          if (matches.length > 0) {
+            matches.forEach(match => {
+              const controlCharacterLength = match[0].length;
+
+              const matchIndexStart = match.index;
+              const matchIndexEnd = matchIndexStart + controlCharacterLength;
+
+              /** @type {Position} */
+              const loc = {
+                start: {
+                  line: lineIndex + ZERO_TO_ONE_BASED_OFFSET,
+                  column: matchIndexStart + ZERO_TO_ONE_BASED_OFFSET,
+                },
+                end: {
+                  line: lineIndex + ZERO_TO_ONE_BASED_OFFSET,
+                  column: matchIndexEnd + ZERO_TO_ONE_BASED_OFFSET,
+                },
+              };
+
+              if (ignoredPositions.isIgnoredPosition(loc)) return;
+
+              context.report({
+                loc,
+
+                data: {
+                  controlCharacter: `U+${match[0].codePointAt(0).toString(16).toUpperCase().padStart(4, '0')}`,
+                },
+
+                messageId: 'noControlCharacter',
+              });
+            });
+          }
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-mark/src/rules/no-control-character/no-control-character.test.js
+++ b/packages/eslint-plugin-mark/src/rules/no-control-character/no-control-character.test.js
@@ -1,0 +1,581 @@
+/**
+ * @fileoverview Test for `no-control-character.js`.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { test } from 'node:test';
+
+import { getFileName } from '../../core/helpers/index.js';
+import { ruleTesterCommonmark, ruleTesterGfm } from '../../core/rule-tester/index.js';
+
+import rule from './no-control-character.js';
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const name = getFileName(import.meta.url);
+const noControlCharacter = 'noControlCharacter';
+
+// --------------------------------------------------------------------------------
+// Testcases
+// --------------------------------------------------------------------------------
+
+const tests = {
+  valid: [
+    {
+      name: 'Empty',
+      code: '',
+    },
+    {
+      name: 'Empty string',
+      code: '  ',
+    },
+    {
+      name: 'control character in code - 1',
+      code: `
+\`\`\`js
+\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u000b\u000c\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008a\u008b\u008c\u008d\u008e\u008f\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f\u202c\u202d\u202e
+\`\`\``,
+    },
+    {
+      name: 'control character in code - 2',
+      code: `
+\`\`\`js\u0000
+console.log(\u0003'Hello World');
+\`\`\``,
+    },
+    {
+      name: 'control character in inline code',
+      code: `\`console.log(\u0004'Hello World')\`
+
+\`console.log(\u0005'Hello World')\``,
+    },
+  ],
+
+  invalid: [
+    // Basic
+    {
+      name: 'control character',
+      code: `
+1\u00002\u00013\u00024\u00035\u00046\u00057\u00068\u00079\u00080\u000b
+1\u000c2\u000e3\u000f4\u00105\u00116\u00127\u00138\u00149\u00150\u0016
+1\u00172\u00183\u00194\u001a5\u001b6\u001c7\u001d8\u001e9\u001f0\u007f
+1\u00802\u00813\u00824\u00835\u00846\u00857\u00868\u00879\u00880\u0089
+1\u008a2\u008b3\u008c4\u008d5\u008e6\u008f7\u00908\u00919\u00920\u0093
+1\u00942\u00953\u00964\u00975\u00986\u00997\u009a8\u009b9\u009c0\u009d
+1\u009e2\u009f3\u202c4\u202d5\u202e`,
+      errors: [
+        {
+          messageId: noControlCharacter,
+          line: 2,
+          column: 2,
+          endLine: 2,
+          endColumn: 3,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 2,
+          column: 4,
+          endLine: 2,
+          endColumn: 5,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 2,
+          column: 6,
+          endLine: 2,
+          endColumn: 7,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 2,
+          column: 8,
+          endLine: 2,
+          endColumn: 9,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 2,
+          column: 10,
+          endLine: 2,
+          endColumn: 11,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 2,
+          column: 12,
+          endLine: 2,
+          endColumn: 13,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 2,
+          column: 14,
+          endLine: 2,
+          endColumn: 15,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 2,
+          column: 16,
+          endLine: 2,
+          endColumn: 17,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 2,
+          column: 18,
+          endLine: 2,
+          endColumn: 19,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 2,
+          column: 20,
+          endLine: 2,
+          endColumn: 21,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 3,
+          column: 2,
+          endLine: 3,
+          endColumn: 3,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 3,
+          column: 4,
+          endLine: 3,
+          endColumn: 5,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 3,
+          column: 6,
+          endLine: 3,
+          endColumn: 7,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 3,
+          column: 8,
+          endLine: 3,
+          endColumn: 9,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 3,
+          column: 10,
+          endLine: 3,
+          endColumn: 11,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 3,
+          column: 12,
+          endLine: 3,
+          endColumn: 13,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 3,
+          column: 14,
+          endLine: 3,
+          endColumn: 15,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 3,
+          column: 16,
+          endLine: 3,
+          endColumn: 17,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 3,
+          column: 18,
+          endLine: 3,
+          endColumn: 19,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 3,
+          column: 20,
+          endLine: 3,
+          endColumn: 21,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 4,
+          column: 2,
+          endLine: 4,
+          endColumn: 3,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 4,
+          column: 4,
+          endLine: 4,
+          endColumn: 5,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 4,
+          column: 6,
+          endLine: 4,
+          endColumn: 7,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 4,
+          column: 8,
+          endLine: 4,
+          endColumn: 9,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 4,
+          column: 10,
+          endLine: 4,
+          endColumn: 11,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 4,
+          column: 12,
+          endLine: 4,
+          endColumn: 13,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 4,
+          column: 14,
+          endLine: 4,
+          endColumn: 15,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 4,
+          column: 16,
+          endLine: 4,
+          endColumn: 17,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 4,
+          column: 18,
+          endLine: 4,
+          endColumn: 19,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 4,
+          column: 20,
+          endLine: 4,
+          endColumn: 21,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 5,
+          column: 2,
+          endLine: 5,
+          endColumn: 3,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 5,
+          column: 4,
+          endLine: 5,
+          endColumn: 5,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 5,
+          column: 6,
+          endLine: 5,
+          endColumn: 7,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 5,
+          column: 8,
+          endLine: 5,
+          endColumn: 9,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 5,
+          column: 10,
+          endLine: 5,
+          endColumn: 11,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 5,
+          column: 12,
+          endLine: 5,
+          endColumn: 13,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 5,
+          column: 14,
+          endLine: 5,
+          endColumn: 15,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 5,
+          column: 16,
+          endLine: 5,
+          endColumn: 17,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 5,
+          column: 18,
+          endLine: 5,
+          endColumn: 19,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 5,
+          column: 20,
+          endLine: 5,
+          endColumn: 21,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 6,
+          column: 2,
+          endLine: 6,
+          endColumn: 3,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 6,
+          column: 4,
+          endLine: 6,
+          endColumn: 5,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 6,
+          column: 6,
+          endLine: 6,
+          endColumn: 7,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 6,
+          column: 8,
+          endLine: 6,
+          endColumn: 9,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 6,
+          column: 10,
+          endLine: 6,
+          endColumn: 11,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 6,
+          column: 12,
+          endLine: 6,
+          endColumn: 13,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 6,
+          column: 14,
+          endLine: 6,
+          endColumn: 15,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 6,
+          column: 16,
+          endLine: 6,
+          endColumn: 17,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 6,
+          column: 18,
+          endLine: 6,
+          endColumn: 19,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 6,
+          column: 20,
+          endLine: 6,
+          endColumn: 21,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 7,
+          column: 2,
+          endLine: 7,
+          endColumn: 3,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 7,
+          column: 4,
+          endLine: 7,
+          endColumn: 5,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 7,
+          column: 6,
+          endLine: 7,
+          endColumn: 7,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 7,
+          column: 8,
+          endLine: 7,
+          endColumn: 9,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 7,
+          column: 10,
+          endLine: 7,
+          endColumn: 11,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 7,
+          column: 12,
+          endLine: 7,
+          endColumn: 13,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 7,
+          column: 14,
+          endLine: 7,
+          endColumn: 15,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 7,
+          column: 16,
+          endLine: 7,
+          endColumn: 17,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 7,
+          column: 18,
+          endLine: 7,
+          endColumn: 19,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 7,
+          column: 20,
+          endLine: 7,
+          endColumn: 21,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 8,
+          column: 2,
+          endLine: 8,
+          endColumn: 3,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 8,
+          column: 4,
+          endLine: 8,
+          endColumn: 5,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 8,
+          column: 6,
+          endLine: 8,
+          endColumn: 7,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 8,
+          column: 8,
+          endLine: 8,
+          endColumn: 9,
+        },
+        {
+          messageId: noControlCharacter,
+          line: 8,
+          column: 10,
+          endLine: 8,
+          endColumn: 11,
+        },
+      ],
+    },
+
+    // Options
+    {
+      name: '`skipCode: false`',
+      code: `
+\`\`\`js
+console.log(\u0005'Hello World');
+\`\`\``,
+      errors: [
+        {
+          messageId: noControlCharacter,
+          line: 3,
+          column: 13,
+          endLine: 3,
+          endColumn: 14,
+        },
+      ],
+      options: [
+        {
+          skipCode: false,
+        },
+      ],
+    },
+    {
+      name: '`skipInlineCode: false`',
+      code: "`console.log(\u0006'Hello World')`",
+      errors: [
+        {
+          messageId: noControlCharacter,
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 15,
+        },
+      ],
+      options: [
+        {
+          skipInlineCode: false,
+        },
+      ],
+    },
+  ],
+};
+
+// --------------------------------------------------------------------------------
+// Test Runner
+// --------------------------------------------------------------------------------
+
+test(name, () => {
+  ruleTesterCommonmark.run(name, rule, tests);
+  ruleTesterGfm.run(name, rule, tests);
+});

--- a/website/docs/rules/no-control-character.md
+++ b/website/docs/rules/no-control-character.md
@@ -1,0 +1,79 @@
+<!-- markdownlint-disable-next-line no-inline-html first-line-h1 -->
+<header v-html="$frontmatter.rule"></header>
+
+## Rule Details
+
+```txt
+\u0000 - Null - <NUL>
+\u0001 - Start of Heading - <SOH>
+\u0002 - Start of Text - <STX>
+\u0003 - End of Text - <ETX>
+\u0004 - End of Transmission - <EOT>
+\u0005 - Enquiry - <ENQ>
+\u0006 - Acknowledge - <ACK>
+\u0007 - Bell - <BEL>
+\u0008 - Backspace - <BS>
+\u000b - Line Tabulation - <VT>
+\u000c - Form Feed - <FF>
+\u000e - Shift Out - <SO>
+\u000f - Shift In - <SI>
+\u0010 - Data Link Escape - <DLE>
+\u0011 - Device Control One - <DC1>
+\u0012 - Device Control Two - <DC2>
+\u0013 - Device Control Three - <DC3>
+\u0014 - Device Control Four - <DC4>
+\u0015 - Negative Acknowledge - <NAK>
+\u0016 - Synchronous Idle - <SYN>
+\u0017 - End of Transmission Block - <ETB>
+\u0018 - Cancel - <CAN>
+\u0019 - End of Medium - <EM>
+\u001a - Substitute - <SUB>
+\u001b - Escape - <ESC>
+\u001c - Information Separator Four - <FS>
+\u001d - Information Separator Three - <GS>
+\u001e - Information Separator Two - <RS>
+\u001f - Information Separator One - <US>
+\u007f - Delete - <DEL>
+\u0080 - Padding Character - <PAD>
+\u0081 - High Octet Preset - <HOP>
+\u0082 - Break Permitted Here - <BPH>
+\u0083 - No Break Here - <NBH>
+\u0084 - Index - <IND>
+\u0085 - Next Line - <NEL>
+\u0086 - Start of Selected Area - <SSA>
+\u0087 - End of Selected Area - <ESA>
+\u0088 - Character Tabulation Set - <HTS>
+\u0089 - Character Tabulation with Justification - <HTJ>
+\u008a - Line Tabulation Set - <VTS>
+\u008b - Partial Line Forward - <PLD>
+\u008c - Partial Line Backward - <PLU>
+\u008d - Reverse Line Feed - <RI>
+\u008e - Single Shift Two - <SS2>
+\u008f - Single Shift Three - <SS3>
+\u0090 - Device Control String - <DCS>
+\u0091 - Private Use One - <PU1>
+\u0092 - Private Use Two - <PU2>
+\u0093 - Set Transmit State - <STS>
+\u0094 - Cancel Character - <CCH>
+\u0095 - Message Waiting - <MW>
+\u0096 - Start of Guarded Area - <SPA>
+\u0097 - End of Guarded Area - <EPA>
+\u0098 - Start of String - <SOS>
+\u0099 - Single Graphic Character Introducer - <SGCI>
+\u009a - Single Character Introducer - <SCI>
+\u009b - Control Sequence Introducer - <CSI>
+\u009c - String Terminator - <ST>
+\u009d - Operating System Command - <OSC>
+\u009e - Privacy Message - <PM>
+\u009f - Application Program Command - <APC>
+\u202c - Pop Directional Formatting - <POPDF>
+\u202d - Left-to-Right Override - <LRO>
+\u202e - Right-to-Left Override - <RLO>
+```
+
+Carriage return(`\r`), line feed(`\n`) and tab(`\t`) are not considered control characters in this rule.
+
+## Prior Art
+
+- [`textlint-rule-no-invalid-control-chracter](https://github.com/textlint-rule/textlint-rule-no-invalid-control-character)
+- [`eslint/no-control-regex`](https://eslint.org/docs/latest/rules/no-control-regex)

--- a/website/docs/rules/no-control-character.md
+++ b/website/docs/rules/no-control-character.md
@@ -114,5 +114,5 @@ This rule applies to the entire document, specifically to the [`Root`](https://g
 
 ## Prior Art
 
-- [`textlint-rule-no-invalid-control-chracter`](https://github.com/textlint-rule/textlint-rule-no-invalid-control-character)
+- [`textlint-rule-no-invalid-control-character`](https://github.com/textlint-rule/textlint-rule-no-invalid-control-character)
 - [`eslint/no-control-regex`](https://eslint.org/docs/latest/rules/no-control-regex)

--- a/website/docs/rules/no-control-character.md
+++ b/website/docs/rules/no-control-character.md
@@ -3,6 +3,18 @@
 
 ## Rule Details
 
+::: info
+
+Carriage return(`\r`), line feed(`\n`) and tab(`\t`) are not reported by this rule.
+
+:::
+
+This rule is aimed at identifying and preventing the use of control characters in Markdown documents. Control characters are non-printing characters primarily used to control the interpretation or display of text, and they can cause issues with Markdown parsers, create inconsistencies in document formatting, and lead to potential rendering problems across different platforms.
+
+The rule helps ensure that no unexpected control characters are present in your Markdown documents, which improves document consistency and prevents potential parsing problems. Control characters can be accidentally introduced when copying content from different sources or through certain keyboard shortcuts and can be difficult to detect visually.
+
+This rule disallows the following control characters except where the options allow:
+
 ```txt
 \u0000 - Null - <NUL>
 \u0001 - Start of Heading - <SOH>
@@ -71,9 +83,36 @@
 \u202e - Right-to-Left Override - <RLO>
 ```
 
-Carriage return(`\r`), line feed(`\n`) and tab(`\t`) are not considered control characters in this rule.
+## Options
+
+```js
+'mark/no-control-character': ['error', {
+  skipCode: true,
+  skipInlineCode: true,
+}]
+```
+
+### `skipCode`
+
+> Default: `true`
+
+`true` allows any control characters in code blocks.
+
+### `skipInlineCode`
+
+> Default: `true`
+
+`true` allows any control characters in inline code.
+
+## When Not To Use It
+
+You might want to disable this rule if you're working with documents that intentionally contain control characters for specific purposes, such as demonstrating control character behavior or working with specialized text formats.
+
+## AST
+
+This rule applies to the entire document, specifically to the [`Root`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#root) node.
 
 ## Prior Art
 
-- [`textlint-rule-no-invalid-control-chracter](https://github.com/textlint-rule/textlint-rule-no-invalid-control-character)
+- [`textlint-rule-no-invalid-control-chracter`](https://github.com/textlint-rule/textlint-rule-no-invalid-control-character)
 - [`eslint/no-control-regex`](https://eslint.org/docs/latest/rules/no-control-regex)


### PR DESCRIPTION
This pull request introduces a new ESLint rule to disallow control characters in Markdown documents and updates related configurations and documentation. The most important changes are summarized below:

### Addition of New Rule

* [`packages/eslint-plugin-mark/src/rules/no-control-character/index.js`](diffhunk://#diff-76bfcde1d6d87c2aed4af69fdc7d92d5628fc1b8cc2ad45aa66c1a94bc2bc799R1-R3): Added the new rule `no-control-character` to disallow control characters in Markdown documents.
* [`packages/eslint-plugin-mark/src/rules/no-control-character/no-control-character.js`](diffhunk://#diff-8d03766e703fb2471ad6f5b6f07dbd94c44a73aba484ea6e1c747217ef9ac7ceR1-R138): Implemented the `no-control-character` rule, including its definition, schema, and logic for detecting control characters.

### Configuration Updates

* [`packages/eslint-plugin-mark/src/configs/all.js`](diffhunk://#diff-dcdf50541cdda584e7b5e20419349e2a8760d86d4d140d12dbd1d97b3084703fR39): Added `mark/no-control-character` rule to the `all` configuration.
* [`packages/eslint-plugin-mark/src/configs/recommended.js`](diffhunk://#diff-5c2e62dd777b6828656ee264af3302d295f3768516f0cf7dfdbaa939848a0c01R38): Added `mark/no-control-character` rule to the `recommended` configuration.

### Documentation

* [`website/docs/rules/no-control-character.md`](diffhunk://#diff-685bee2afe49dbd445fdc35722b45023eb5d3ae86faf8abd4dcf4abb3f41ea0aR1-R118): Created documentation for the `no-control-character` rule, detailing its purpose, options, and prior art.

### Rule Integration

* [`packages/eslint-plugin-mark/src/rules/index.js`](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R7): Imported and exported the `no-control-character` rule in the rules index file. [[1]](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R7) [[2]](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R20)

These changes ensure that control characters are properly detected and reported in Markdown documents, improving document consistency and preventing potential parsing issues.