### PR TITLE
feat(eslint-plugin-mark): create `image-title` rule

### DIFF
--- a/packages/eslint-plugin-mark/src/configs/all.js
+++ b/packages/eslint-plugin-mark/src/configs/all.js
@@ -37,6 +37,7 @@ export default function all(parserMode) {
       'mark/code-lang-shorthand': 'error',
       'mark/en-capitalization': 'error',
       'mark/heading-id': 'warn',
+      'mark/image-title': 'error',
       'mark/no-bold-paragraph': 'error',
       'mark/no-control-character': 'error',
       'mark/no-curly-quote': 'error',

--- a/packages/eslint-plugin-mark/src/configs/all.js
+++ b/packages/eslint-plugin-mark/src/configs/all.js
@@ -37,7 +37,7 @@ export default function all(parserMode) {
       'mark/code-lang-shorthand': 'error',
       'mark/en-capitalization': 'error',
       'mark/heading-id': 'warn',
-      'mark/image-title': 'error',
+      'mark/image-title': 'warn',
       'mark/no-bold-paragraph': 'error',
       'mark/no-control-character': 'error',
       'mark/no-curly-quote': 'error',

--- a/packages/eslint-plugin-mark/src/core/ast/index.js
+++ b/packages/eslint-plugin-mark/src/core/ast/index.js
@@ -1,6 +1,7 @@
 /* eslint sort-imports: 'error', sort-keys: 'error' */
 
 import IgnoredPositions from './ignored-positions/index.js';
+import ReferenceDefinitionHandler from './reference-definition-handler/index.js';
 import textHandler from './text-handler/index.js';
 
-export { IgnoredPositions, textHandler };
+export { IgnoredPositions, ReferenceDefinitionHandler, textHandler };

--- a/packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/index.js
+++ b/packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/index.js
@@ -1,0 +1,3 @@
+import ReferenceDefinitionHandler from './reference-definition-handler.js';
+
+export default ReferenceDefinitionHandler;

--- a/packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/reference-definition-handler.js
+++ b/packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/reference-definition-handler.js
@@ -47,6 +47,8 @@ export default class ReferenceDefinitionHandler {
     } else if (node.type === 'definition') {
       this.#definitions.push(node);
     }
+
+    return this;
   }
 
   /**

--- a/packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/reference-definition-handler.js
+++ b/packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/reference-definition-handler.js
@@ -1,0 +1,106 @@
+/**
+ * @fileoverview Class to manage `ImageReference` and `LinkReference` nodes, along with their corresponding `Definition` nodes.
+ */
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {import("mdast").ImageReference} ImageReference
+ * @typedef {import("mdast").LinkReference} LinkReference
+ * @typedef {import("mdast").Definition} Definition
+ */
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Class to manage `ImageReference` and `LinkReference` nodes, along with their corresponding `Definition` nodes.
+ */
+export default class ReferenceDefinitionHandler {
+  // ------------------------------------------------------------------------------
+  // Private Properties
+  // ------------------------------------------------------------------------------
+
+  /** @type {ImageReference[]} */
+  #imageReferences = [];
+  /** @type {LinkReference[]} */
+  #linkReferences = [];
+  /** @type {Definition[]} */
+  #definitions = [];
+
+  // ------------------------------------------------------------------------------
+  // Public Methods
+  // ------------------------------------------------------------------------------
+
+  /**
+   * Push an `ImageReference`, `LinkReference` or `Definition` node to the appropriate array.
+   * @param {ImageReference | LinkReference | Definition} node
+   */
+  push(node) {
+    if (node.type === 'imageReference') {
+      this.#imageReferences.push(node);
+    } else if (node.type === 'linkReference') {
+      this.#linkReferences.push(node);
+    } else if (node.type === 'definition') {
+      this.#definitions.push(node);
+    }
+  }
+
+  /**
+   * Check if a `Definition` node is an image definition.
+   * @param {Definition} node
+   */
+  isImageDefinition(node) {
+    return this.#imageReferences.some(ref => ref.identifier === node.identifier);
+  }
+
+  /**
+   * Check if a `Definition` node is a link definition.
+   * @param {Definition} node
+   */
+  isLinkDefinition(node) {
+    return this.#linkReferences.some(ref => ref.identifier === node.identifier);
+  }
+
+  /**
+   * Get all `Definition` nodes that are image definitions.
+   */
+  getImageDefinitions() {
+    return this.#definitions.filter(def => this.isImageDefinition(def));
+  }
+
+  /**
+   * Get all `Definition` nodes that are link definitions.
+   */
+  getLinkDefinitions() {
+    return this.#definitions.filter(def => this.isLinkDefinition(def));
+  }
+
+  // ------------------------------------------------------------------------------
+  // Getters and Setters
+  // ------------------------------------------------------------------------------
+
+  /**
+   * Get the `ImageReference` nodes.
+   */
+  get imageReferences() {
+    return this.#imageReferences;
+  }
+
+  /**
+   * Get the `LinkReference` nodes.
+   */
+  get linkReferences() {
+    return this.#linkReferences;
+  }
+
+  /**
+   * Get the `Definition` nodes.
+   */
+  get definitions() {
+    return this.#definitions;
+  }
+}

--- a/packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/reference-definition-handler.test.js
+++ b/packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/reference-definition-handler.test.js
@@ -1,0 +1,209 @@
+/**
+ * @fileoverview Test for `reference-definition-handler.js`.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { describe, it } from 'node:test';
+import { deepStrictEqual, strictEqual } from 'node:assert';
+
+import { getFileName } from '../../helpers/index.js';
+
+import ReferenceDefinitionHandler from './reference-definition-handler.js';
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const imageReference1 = {
+  type: 'imageReference',
+  alt: '',
+  position: {
+    start: {
+      line: 1,
+      column: 1,
+      offset: 0,
+    },
+    end: {
+      line: 1,
+      column: 12,
+      offset: 11,
+    },
+  },
+  label: 'image1',
+  identifier: 'image1',
+  referenceType: 'full',
+};
+
+const imageReference2 = {
+  type: 'imageReference',
+  alt: '',
+  position: {
+    start: {
+      line: 9,
+      column: 1,
+      offset: 102,
+    },
+    end: {
+      line: 9,
+      column: 12,
+      offset: 113,
+    },
+  },
+  label: 'common',
+  identifier: 'common',
+  referenceType: 'full',
+};
+
+const linkReference1 = {
+  type: 'linkReference',
+  children: [],
+  position: {
+    start: {
+      line: 5,
+      column: 1,
+      offset: 55,
+    },
+    end: {
+      line: 5,
+      column: 10,
+      offset: 64,
+    },
+  },
+  label: 'link1',
+  identifier: 'link1',
+  referenceType: 'full',
+};
+
+const linkReference2 = {
+  type: 'linkReference',
+  children: [],
+  position: {
+    start: {
+      line: 10,
+      column: 1,
+      offset: 114,
+    },
+    end: {
+      line: 10,
+      column: 11,
+      offset: 124,
+    },
+  },
+  label: 'common',
+  identifier: 'common',
+  referenceType: 'full',
+};
+
+const definition1 = {
+  type: 'definition',
+  identifier: 'image1',
+  label: 'image1',
+  title: null,
+  url: 'https://example.com/image1.jpg',
+  position: {
+    start: {
+      line: 3,
+      column: 1,
+      offset: 13,
+    },
+    end: {
+      line: 3,
+      column: 41,
+      offset: 53,
+    },
+  },
+};
+
+const definition2 = {
+  type: 'definition',
+  identifier: 'link1',
+  label: 'link1',
+  title: null,
+  url: 'https://example.com/link1',
+  position: {
+    start: {
+      line: 7,
+      column: 1,
+      offset: 66,
+    },
+    end: {
+      line: 7,
+      column: 35,
+      offset: 100,
+    },
+  },
+};
+
+const definition3 = {
+  type: 'definition',
+  identifier: 'common',
+  label: 'common',
+  title: null,
+  url: 'https://example.com/common',
+  position: {
+    start: {
+      line: 12,
+      column: 1,
+      offset: 126,
+    },
+    end: {
+      line: 12,
+      column: 37,
+      offset: 162,
+    },
+  },
+};
+
+const refDefHandler = new ReferenceDefinitionHandler()
+  .push(imageReference1)
+  .push(imageReference2)
+  .push(linkReference1)
+  .push(linkReference2)
+  .push(definition1)
+  .push(definition2)
+  .push(definition3);
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe(getFileName(import.meta.url), () => {
+  describe('push()', () => {
+    it('should push nodes to the list correctly', () => {
+      deepStrictEqual(refDefHandler.imageReferences, [imageReference1, imageReference2]);
+      deepStrictEqual(refDefHandler.linkReferences, [linkReference1, linkReference2]);
+      deepStrictEqual(refDefHandler.definitions, [definition1, definition2, definition3]);
+    });
+  });
+
+  describe('isImageDefinition()', () => {
+    it('should return true for image definitions', () => {
+      strictEqual(refDefHandler.isImageDefinition(definition1), true);
+      strictEqual(refDefHandler.isImageDefinition(definition2), false);
+      strictEqual(refDefHandler.isImageDefinition(definition3), true);
+    });
+  });
+
+  describe('isLinkDefinition()', () => {
+    it('should return true for link definitions', () => {
+      strictEqual(refDefHandler.isLinkDefinition(definition1), false);
+      strictEqual(refDefHandler.isLinkDefinition(definition2), true);
+      strictEqual(refDefHandler.isLinkDefinition(definition3), true);
+    });
+  });
+
+  describe('getImageDefinitions()', () => {
+    it('should return image definitions', () => {
+      deepStrictEqual(refDefHandler.getImageDefinitions(), [definition1, definition3]);
+    });
+  });
+
+  describe('getLinkDefinitions()', () => {
+    it('should return link definitions', () => {
+      deepStrictEqual(refDefHandler.getLinkDefinitions(), [definition2, definition3]);
+    });
+  });
+});

--- a/packages/eslint-plugin-mark/src/rules/image-title/image-title.js
+++ b/packages/eslint-plugin-mark/src/rules/image-title/image-title.js
@@ -1,0 +1,106 @@
+/**
+ * @fileoverview Rule to enforce the use of title attribute for images.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import * as cheerio from 'cheerio';
+import { ReferenceDefinitionHandler } from '../../core/ast/index.js';
+import { getRuleDocsUrl } from '../../core/helpers/index.js';
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {import("@eslint/markdown").RuleModule} RuleModule
+ * @typedef {import("mdast").Image} Image
+ * @typedef {import("mdast").ImageReference} ImageReference
+ * @typedef {import("mdast").Definition} Definition
+ * @typedef {import("mdast").Html} Html
+ */
+
+// --------------------------------------------------------------------------------
+// Rule Definition
+// --------------------------------------------------------------------------------
+
+/** @type {RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      recommended: false,
+      description: 'Enforce the use of title attribute for images',
+      url: getRuleDocsUrl('image-title'),
+    },
+
+    messages: {
+      imageTitle: 'Images should have a title attribute.',
+    },
+
+    language: 'markdown',
+
+    dialects: ['commonmark', 'gfm'],
+  },
+
+  create(context) {
+    const refDefHandler = new ReferenceDefinitionHandler();
+
+    return {
+      /** @param {Image} node */
+      image(node) {
+        if (!node.title) {
+          context.report({
+            // @ts-expect-error -- TODO
+            node,
+            messageId: 'imageTitle',
+          });
+        }
+      },
+
+      /** @param {Html} node */
+      html(node) {
+        const $ = cheerio.load(node.value);
+
+        $('img').each((_, elem) => {
+          if (!elem.attribs.title) {
+            context.report({
+              // @ts-expect-error -- TODO
+              node,
+              messageId: 'imageTitle',
+            });
+          }
+        });
+      },
+
+      /** @param {ImageReference} node */
+      imageReference(node) {
+        refDefHandler.push(node);
+      },
+
+      /** @param {Definition} node */
+      definition(node) {
+        refDefHandler.push(node);
+      },
+
+      // TODO: Enable `'root:exit'()` syntax.
+      'root:exit': function () {
+        const imageDefinitions = refDefHandler.getImageDefinitions();
+
+        imageDefinitions.forEach(definition => {
+          if (!definition.title) {
+            context.report({
+              // @ts-expect-error -- TODO
+              node: definition,
+              messageId: 'imageTitle',
+            });
+          }
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-mark/src/rules/image-title/image-title.js
+++ b/packages/eslint-plugin-mark/src/rules/image-title/image-title.js
@@ -50,16 +50,19 @@ export default {
   create(context) {
     const refDefHandler = new ReferenceDefinitionHandler();
 
+    /** @param {Image | ImageReference | Definition | Html} node */
+    function report(node) {
+      context.report({
+        // @ts-expect-error -- TODO
+        node,
+        messageId: 'imageTitle',
+      });
+    }
+
     return {
       /** @param {Image} node */
       image(node) {
-        if (!node.title) {
-          context.report({
-            // @ts-expect-error -- TODO
-            node,
-            messageId: 'imageTitle',
-          });
-        }
+        if (!node.title) report(node);
       },
 
       /** @param {Html} node */
@@ -67,13 +70,7 @@ export default {
         const $ = cheerio.load(node.value);
 
         $('img').each((_, elem) => {
-          if (!elem.attribs.title) {
-            context.report({
-              // @ts-expect-error -- TODO
-              node,
-              messageId: 'imageTitle',
-            });
-          }
+          if (!elem.attribs.title) report(node);
         });
       },
 
@@ -89,16 +86,8 @@ export default {
 
       // TODO: Enable `'root:exit'()` syntax.
       'root:exit': function () {
-        const imageDefinitions = refDefHandler.getImageDefinitions();
-
-        imageDefinitions.forEach(definition => {
-          if (!definition.title) {
-            context.report({
-              // @ts-expect-error -- TODO
-              node: definition,
-              messageId: 'imageTitle',
-            });
-          }
+        refDefHandler.getImageDefinitions().forEach(definition => {
+          if (!definition.title) report(definition);
         });
       },
     };

--- a/packages/eslint-plugin-mark/src/rules/image-title/image-title.test.js
+++ b/packages/eslint-plugin-mark/src/rules/image-title/image-title.test.js
@@ -1,0 +1,177 @@
+/**
+ * @fileoverview Test for `image-title.js`.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { test } from 'node:test';
+
+import { getFileName } from '../../core/helpers/index.js';
+import { ruleTesterCommonmark, ruleTesterGfm } from '../../core/rule-tester/index.js';
+
+import rule from './image-title.js';
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const name = getFileName(import.meta.url);
+const imageTitle = 'imageTitle';
+
+// --------------------------------------------------------------------------------
+// Testcases
+// --------------------------------------------------------------------------------
+
+const tests = {
+  valid: [
+    {
+      name: 'Empty',
+      code: '',
+    },
+    {
+      name: 'Empty string',
+      code: '  ',
+    },
+    {
+      name: 'Image node with title attribute',
+      code: '![](https://example.com/image.jpg "title")',
+    },
+    {
+      name: 'ImageReference node with title attribute',
+      code: `
+![alt text][image]
+
+[image]: https://example.com/image.jpg "title"
+`,
+    },
+    {
+      name: 'Html node with title attribute',
+      code: '<img src="https://example.com/image.jpg" title="title">',
+    },
+    {
+      name: 'Nested Html node with title attribute',
+      code: `
+<div>
+  <img src="https://example.com/image.jpg" title="title">
+</div>
+`,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'Image node without title attribute',
+      code: '![](https://example.com/image.jpg)',
+      errors: [
+        {
+          messageId: imageTitle,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 35,
+        },
+      ],
+    },
+    {
+      name: 'Image node with empty title attribute',
+      code: '![](https://example.com/image.jpg "")',
+      errors: [
+        {
+          messageId: imageTitle,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 38,
+        },
+      ],
+    },
+
+    {
+      name: 'ImageReference node without title attribute',
+      code: `
+![alt text][image]
+
+[image]: https://example.com/image.jpg`,
+      errors: [
+        {
+          messageId: imageTitle,
+          line: 4,
+          column: 1,
+          endLine: 4,
+          endColumn: 39,
+        },
+      ],
+    },
+    {
+      name: 'ImageReference node with empty title attribute',
+      code: `
+![alt text][image]
+
+[image]: https://example.com/image.jpg ""`,
+      errors: [
+        {
+          messageId: imageTitle,
+          line: 4,
+          column: 1,
+          endLine: 4,
+          endColumn: 42,
+        },
+      ],
+    },
+
+    {
+      name: 'Html node without title attribute',
+      code: '<img src="https://example.com/image.jpg">',
+      errors: [
+        {
+          messageId: imageTitle,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 42,
+        },
+      ],
+    },
+    {
+      name: 'Html node with empty title attribute',
+      code: '<img src="https://example.com/image.jpg" title="">',
+      errors: [
+        {
+          messageId: imageTitle,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      name: 'Nested Html node without title attribute',
+      code: `
+<div>
+  <img src="https://example.com/image.jpg">
+</div>`,
+      errors: [
+        {
+          messageId: imageTitle,
+          line: 2,
+          column: 1,
+          endLine: 4,
+          endColumn: 7,
+        },
+      ],
+    },
+  ],
+};
+
+// --------------------------------------------------------------------------------
+// Test Runner
+// --------------------------------------------------------------------------------
+
+test(name, () => {
+  ruleTesterCommonmark.run(name, rule, tests);
+  ruleTesterGfm.run(name, rule, tests);
+});

--- a/packages/eslint-plugin-mark/src/rules/image-title/index.js
+++ b/packages/eslint-plugin-mark/src/rules/image-title/index.js
@@ -1,0 +1,3 @@
+import imageTitle from './image-title.js';
+
+export default imageTitle;

--- a/packages/eslint-plugin-mark/src/rules/index.js
+++ b/packages/eslint-plugin-mark/src/rules/index.js
@@ -5,6 +5,7 @@ import altText from './alt-text/index.js';
 import codeLangShorthand from './code-lang-shorthand/index.js';
 import enCapitalization from './en-capitalization/index.js';
 import headingId from './heading-id/index.js';
+import imageTitle from './image-title/index.js';
 import noBoldParagraph from './no-bold-paragraph/index.js';
 import noControlCharacter from './no-control-character/index.js';
 import noCurlyQuote from './no-curly-quote/index.js';
@@ -20,6 +21,7 @@ export default {
   'code-lang-shorthand': codeLangShorthand,
   'en-capitalization': enCapitalization,
   'heading-id': headingId,
+  'image-title': imageTitle,
   'no-bold-paragraph': noBoldParagraph,
   'no-control-character': noControlCharacter,
   'no-curly-quote': noCurlyQuote,

--- a/website/docs/rules/image-title.md
+++ b/website/docs/rules/image-title.md
@@ -1,0 +1,62 @@
+<!-- markdownlint-disable-next-line no-inline-html first-line-h1 -->
+<header v-html="$frontmatter.rule"></header>
+
+## Rule Details
+
+This rule enforces the use of title attributes for all images in Markdown documents. Having title attributes on images provides additional context and can improve accessibility by offering supplementary information when hovering over an image.
+
+The rule examines all image elements in a Markdown document and reports any images that lack a title attribute. It checks:
+
+- Standard Markdown image syntax: `![alt text](url "title")`
+- Image reference definitions: `[ref]: url "title"`
+- HTML image tags: `<img src="url" alt="alt text" title="title">`
+
+## Examples
+
+### :x: Incorrect
+
+Examples of **incorrect** code for this rule:
+
+```md
+![Alt text](https://example.com/image.png)
+
+<img src="https://example.com/image.png" alt="Alt text">
+
+![Alt text][reference]
+
+[reference]: https://example.com/image.png
+```
+
+### :white_check_mark: Correct
+
+Examples of **correct** code for this rule:
+
+```md
+![Alt text](https://example.com/image.png "Image title")
+
+<img src="https://example.com/image.png" alt="Alt text" title="Image title">
+
+![Alt text][reference]
+
+[reference]: https://example.com/image.png "Image title"
+```
+
+## When Not To Use It
+
+You might want to disable this rule if:
+
+- Your documentation style guide doesn't require image titles
+- You're working with legacy documentation where adding titles to all images would be impractical
+- You're using a documentation system that provides alternative methods for image descriptions or captions
+
+## Options
+
+No options are available for this rule.
+
+## AST
+
+This rule examines the following AST node types:
+
+- [`Image`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#image) nodes for standard Markdown image syntax
+- [`Html`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#html) nodes to check for `<img>` tags
+- [`ImageReference`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#imagereference) and [`Definition`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#definition) nodes for referenced images


### PR DESCRIPTION
This pull request introduces a new rule to enforce the use of title attributes for images in Markdown documents. It includes the implementation of the rule, updates to the configuration files, and corresponding tests and documentation.

New rule implementation:

* [`packages/eslint-plugin-mark/src/rules/image-title/image-title.js`](diffhunk://#diff-d8ba748806ee139927f1d01c6a50e08e3e11fbd5e641eb0d9341b176862176faR1-R95): Added a new rule to enforce the use of title attributes for images. This rule checks standard Markdown image syntax, image reference definitions, and HTML image tags.
* [`packages/eslint-plugin-mark/src/rules/image-title/image-title.test.js`](diffhunk://#diff-993e4680f978eda002e34c282e1e35cd70c4edfd098f7278ae1a2f640fae5152R1-R177): Added tests for the new image title rule to ensure it correctly identifies images without title attributes and validates those with them.
* [`packages/eslint-plugin-mark/src/rules/image-title/index.js`](diffhunk://#diff-cc195e97e2eeaa58d8fedc77534fbd9518eb265ab3c2c0817339d2e33d968d31R1-R3): Exported the new image title rule.

Configuration updates:

* [`packages/eslint-plugin-mark/src/rules/index.js`](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R8): Updated to include the new image title rule in the list of available rules. [[1]](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R8) [[2]](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R24)
* [`packages/eslint-plugin-mark/src/configs/all.js`](diffhunk://#diff-dcdf50541cdda584e7b5e20419349e2a8760d86d4d140d12dbd1d97b3084703fR40): Set the new image title rule to 'error' in the configuration.

Documentation:

* [`website/docs/rules/image-title.md`](diffhunk://#diff-1200490758bbba4ba6ca0f835674d7b1ff2ff8cf18eec33b99e4d3aa529d5249R1-R62): Added documentation for the new image title rule, detailing its purpose, examples of correct and incorrect usage, and scenarios for when not to use it.