### PR TITLE
refactor(eslint-plugin-mark): redesign `text-handler` class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4356,6 +4356,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
@@ -20380,7 +20381,6 @@
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^6.3.0",
-        "@types/mdast": "^4.0.4",
         "cheerio": "^1.0.0",
         "emoji-regex": "^10.4.0"
       },
@@ -20389,15 +20389,6 @@
       },
       "peerDependencies": {
         "eslint": "^9.0.0"
-      }
-    },
-    "packages/eslint-plugin-mark/node_modules/@types/mdast": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
       }
     },
     "packages/eslint-plugin-mark/node_modules/emoji-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20385,10 +20385,21 @@
         "emoji-regex": "^10.4.0"
       },
       "devDependencies": {
+        "@types/mdast": "^4.0.4",
         "eslint": "^9.23.0"
       },
       "peerDependencies": {
         "eslint": "^9.0.0"
+      }
+    },
+    "packages/eslint-plugin-mark/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "packages/eslint-plugin-mark/node_modules/emoji-regex": {

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -83,7 +83,6 @@
   },
   "dependencies": {
     "@eslint/markdown": "^6.3.0",
-    "@types/mdast": "^4.0.4",
     "cheerio": "^1.0.0",
     "emoji-regex": "^10.4.0"
   },

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -87,6 +87,7 @@
     "emoji-regex": "^10.4.0"
   },
   "devDependencies": {
+    "@types/mdast": "^4.0.4",
     "eslint": "^9.23.0"
   }
 }

--- a/packages/eslint-plugin-mark/src/core/ast/index.js
+++ b/packages/eslint-plugin-mark/src/core/ast/index.js
@@ -2,6 +2,6 @@
 
 import IgnoredPositions from './ignored-positions/index.js';
 import ReferenceDefinitionHandler from './reference-definition-handler/index.js';
-import textHandler from './text-handler/index.js';
+import TextHandler from './text-handler/index.js';
 
-export { IgnoredPositions, ReferenceDefinitionHandler, textHandler };
+export { IgnoredPositions, ReferenceDefinitionHandler, TextHandler };

--- a/packages/eslint-plugin-mark/src/core/ast/text-handler/index.js
+++ b/packages/eslint-plugin-mark/src/core/ast/text-handler/index.js
@@ -1,3 +1,3 @@
-import textHandler from './text-handler.js';
+import TextHandler from './text-handler.js';
 
-export default textHandler;
+export default TextHandler;

--- a/packages/eslint-plugin-mark/src/core/ast/text-handler/text-handler.test.js
+++ b/packages/eslint-plugin-mark/src/core/ast/text-handler/text-handler.test.js
@@ -11,14 +11,14 @@ import { deepStrictEqual } from 'node:assert';
 
 import { getFileName } from '../../tests/index.js';
 
-import textHandler from './text-handler.js';
+import TextHandler from './text-handler.js';
 
 // --------------------------------------------------------------------------------
 // Test
 // --------------------------------------------------------------------------------
 
 describe(getFileName(import.meta.url), () => {
-  it('should return correct `TextExt` node: singleline', () => {
+  it('should return correct lines: singleline', () => {
     const text = 'foo';
     const context = {
       sourceCode: {
@@ -35,11 +35,10 @@ describe(getFileName(import.meta.url), () => {
       },
     };
 
-    textHandler(context, textNode);
+    const textHandler = new TextHandler(context, textNode);
 
-    deepStrictEqual(textNode.children, [
+    deepStrictEqual(textHandler.lines, [
       {
-        type: 'textLine',
         value: 'foo',
         position: {
           start: {
@@ -57,7 +56,7 @@ describe(getFileName(import.meta.url), () => {
     ]);
   });
 
-  it('should return correct `TextExt` node: multiline', () => {
+  it('should return correct lines: multiline', () => {
     const text = `foo
   bar
 baz`;
@@ -76,11 +75,10 @@ baz`;
       },
     };
 
-    textHandler(context, textNode);
+    const textHandler = new TextHandler(context, textNode);
 
-    deepStrictEqual(textNode.children, [
+    deepStrictEqual(textHandler.lines, [
       {
-        type: 'textLine',
         value: 'foo',
         position: {
           start: {
@@ -96,7 +94,6 @@ baz`;
         },
       },
       {
-        type: 'textLine',
         value: '  bar',
         position: {
           start: {
@@ -112,7 +109,6 @@ baz`;
         },
       },
       {
-        type: 'textLine',
         value: 'baz',
         position: {
           start: {

--- a/packages/eslint-plugin-mark/src/core/types.d.ts
+++ b/packages/eslint-plugin-mark/src/core/types.d.ts
@@ -3,35 +3,5 @@
  */
 
 // --------------------------------------------------------------------------------
-// Import
-// --------------------------------------------------------------------------------
-
-import type { Literal, Text } from 'mdast';
-
-// --------------------------------------------------------------------------------
 // Typedefs
 // --------------------------------------------------------------------------------
-
-/**
- * Custom markdown text extension.
- */
-export interface TextExt extends Text {
-  /**
-   * Node type of custom markdown text extension.
-   */
-  type: 'textExt';
-  /**
-   * Children of the node.
-   */
-  children?: TextLine[] | undefined;
-}
-
-/**
- * Custom markdown text line.
- */
-export interface TextLine extends Literal {
-  /**
-   * Node type of custom markdown text line.
-   */
-  type: 'textLine';
-}

--- a/packages/eslint-plugin-mark/src/rules/no-curly-quote/no-curly-quote.js
+++ b/packages/eslint-plugin-mark/src/rules/no-curly-quote/no-curly-quote.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { textHandler } from '../../core/ast/index.js';
+import { TextHandler } from '../../core/ast/index.js';
 import { URL_RULE_DOCS } from '../../core/constants.js';
 
 // --------------------------------------------------------------------------------
@@ -16,7 +16,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 
 /**
  * @typedef {import("@eslint/markdown").RuleModule} RuleModule
- * @typedef {import("../../core/types.d.ts").TextExt} TextExt
+ * @typedef {import("mdast").Text} Text
  */
 
 // --------------------------------------------------------------------------------
@@ -89,9 +89,9 @@ export default {
 
   create(context) {
     return {
-      /** @param {TextExt} node */
+      /** @param {Text} node */
       text(node) {
-        textHandler(context, node);
+        const textHandler = new TextHandler(context, node);
 
         const [
           {
@@ -114,7 +114,7 @@ export default {
 
         if (!regexString) return;
 
-        node.children.forEach(textLineNode => {
+        textHandler.lines.forEach(textLineNode => {
           const matches = [
             ...textLineNode.value.matchAll(new RegExp(`[${regexString}]`, 'g')),
           ];

--- a/packages/eslint-plugin-mark/src/rules/no-double-space/no-double-space.js
+++ b/packages/eslint-plugin-mark/src/rules/no-double-space/no-double-space.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { textHandler } from '../../core/ast/index.js';
+import { TextHandler } from '../../core/ast/index.js';
 import { URL_RULE_DOCS } from '../../core/constants.js';
 
 // --------------------------------------------------------------------------------
@@ -16,7 +16,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 
 /**
  * @typedef {import("@eslint/markdown").RuleModule} RuleModule
- * @typedef {import("../../core/types.d.ts").TextExt} TextExt
+ * @typedef {import("mdast").Text} Text
  */
 
 // --------------------------------------------------------------------------------
@@ -78,16 +78,16 @@ export default {
 
   create(context) {
     return {
-      /** @param {TextExt} node */
+      /** @param {Text} node */
       text(node) {
-        textHandler(context, node);
+        const textHandler = new TextHandler(context, node);
 
         // @ts-expect-error -- TODO
         const [{ multipleSpace }] = context.options;
         const spaceRegex = multipleSpace ? multipleSpaceRegex : doubleSpaceRegex;
         const messageId = multipleSpace ? 'noMultipleSpace' : 'noDoubleSpace';
 
-        node.children.forEach(textLineNode => {
+        textHandler.lines.forEach(textLineNode => {
           const matches = [...textLineNode.value.trim().matchAll(spaceRegex)];
 
           if (matches.length > 0) {

--- a/packages/eslint-plugin-mark/src/rules/no-emoji/no-emoji.js
+++ b/packages/eslint-plugin-mark/src/rules/no-emoji/no-emoji.js
@@ -9,7 +9,7 @@
 
 import emojiRegex from 'emoji-regex';
 
-import { textHandler } from '../../core/ast/index.js';
+import { TextHandler } from '../../core/ast/index.js';
 import { URL_RULE_DOCS } from '../../core/constants.js';
 
 // --------------------------------------------------------------------------------
@@ -18,7 +18,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 
 /**
  * @typedef {import("@eslint/markdown").RuleModule} RuleModule
- * @typedef {import("../../core/types.d.ts").TextExt} TextExt
+ * @typedef {import("mdast").Text} Text
  */
 
 // --------------------------------------------------------------------------------
@@ -47,11 +47,11 @@ export default {
 
   create(context) {
     return {
-      /** @param {TextExt} node */
+      /** @param {Text} node */
       text(node) {
-        textHandler(context, node);
+        const textHandler = new TextHandler(context, node);
 
-        node.children.forEach(textLineNode => {
+        textHandler.lines.forEach(textLineNode => {
           const matches = [...textLineNode.value.matchAll(emojiRegex())];
 
           if (matches.length > 0) {


### PR DESCRIPTION
This pull request focuses on refactoring the `TextHandler` to be a class and updating its usage across various files. Additionally, it removes the dependency on `@types/mdast`.

### Refactoring to `TextHandler` class:

* [`packages/eslint-plugin-mark/src/core/ast/text-handler/index.js`](diffhunk://#diff-1e470e6a321c1024e1ea996172aeac6edc42e119df9038a8e3a2b672e12d3091L1-R3): Changed `textHandler` to `TextHandler` and updated the export accordingly.
* [`packages/eslint-plugin-mark/src/core/ast/text-handler/text-handler.js`](diffhunk://#diff-5398916d413200c44e3917c35358e2c837f7784fc9cc58fd6d07831985cb8d94L2-R2): Refactored `textHandler` function to `TextHandler` class, including changes to handle `Text` nodes and manage lines as a private property with a getter. [[1]](diffhunk://#diff-5398916d413200c44e3917c35358e2c837f7784fc9cc58fd6d07831985cb8d94L2-R2) [[2]](diffhunk://#diff-5398916d413200c44e3917c35358e2c837f7784fc9cc58fd6d07831985cb8d94L17-R24) [[3]](diffhunk://#diff-5398916d413200c44e3917c35358e2c837f7784fc9cc58fd6d07831985cb8d94L32-R51) [[4]](diffhunk://#diff-5398916d413200c44e3917c35358e2c837f7784fc9cc58fd6d07831985cb8d94L62-R71) [[5]](diffhunk://#diff-5398916d413200c44e3917c35358e2c837f7784fc9cc58fd6d07831985cb8d94R89-R100)

### Updates in test files:

* [`packages/eslint-plugin-mark/src/core/ast/text-handler/text-handler.test.js`](diffhunk://#diff-deb2a322685569f693a9dab33bee793030a0edd6ae061671186ef32f2c9a107eL14-R21): Updated tests to use `TextHandler` class and modified test descriptions to reflect changes. [[1]](diffhunk://#diff-deb2a322685569f693a9dab33bee793030a0edd6ae061671186ef32f2c9a107eL14-R21) [[2]](diffhunk://#diff-deb2a322685569f693a9dab33bee793030a0edd6ae061671186ef32f2c9a107eL38-L42) [[3]](diffhunk://#diff-deb2a322685569f693a9dab33bee793030a0edd6ae061671186ef32f2c9a107eL60-R59) [[4]](diffhunk://#diff-deb2a322685569f693a9dab33bee793030a0edd6ae061671186ef32f2c9a107eL79-L83) [[5]](diffhunk://#diff-deb2a322685569f693a9dab33bee793030a0edd6ae061671186ef32f2c9a107eL99) [[6]](diffhunk://#diff-deb2a322685569f693a9dab33bee793030a0edd6ae061671186ef32f2c9a107eL115)

### Dependency removal:

* [`packages/eslint-plugin-mark/package.json`](diffhunk://#diff-9b9400561d26b4f60200e53b8fbb54b0ef18955f8348a54f396c6ac386667a0dL86): Removed `@types/mdast` dependency.

### Updates in rule files:

* [`packages/eslint-plugin-mark/src/rules/no-curly-quote/no-curly-quote.js`](diffhunk://#diff-f07d349d38a9d669eeaf3c2a3d369b95cd858048da1d815e4fcc0cf495525ba0L10-R10): Updated to use `TextHandler` class and modified type definitions accordingly. [[1]](diffhunk://#diff-f07d349d38a9d669eeaf3c2a3d369b95cd858048da1d815e4fcc0cf495525ba0L10-R10) [[2]](diffhunk://#diff-f07d349d38a9d669eeaf3c2a3d369b95cd858048da1d815e4fcc0cf495525ba0L19-R19) [[3]](diffhunk://#diff-f07d349d38a9d669eeaf3c2a3d369b95cd858048da1d815e4fcc0cf495525ba0L92-R94) [[4]](diffhunk://#diff-f07d349d38a9d669eeaf3c2a3d369b95cd858048da1d815e4fcc0cf495525ba0L117-R117)
* [`packages/eslint-plugin-mark/src/rules/no-double-space/no-double-space.js`](diffhunk://#diff-279d5c20e3f61c9862ba798b78492df0a43e70bc5d724cc593f914c8b1037c3fL10-R10): Updated to use `TextHandler` class and modified type definitions accordingly. [[1]](diffhunk://#diff-279d5c20e3f61c9862ba798b78492df0a43e70bc5d724cc593f914c8b1037c3fL10-R10) [[2]](diffhunk://#diff-279d5c20e3f61c9862ba798b78492df0a43e70bc5d724cc593f914c8b1037c3fL19-R19) [[3]](diffhunk://#diff-279d5c20e3f61c9862ba798b78492df0a43e70bc5d724cc593f914c8b1037c3fL81-R90)
* [`packages/eslint-plugin-mark/src/rules/no-emoji/no-emoji.js`](diffhunk://#diff-707b0f8455353358a18744406669218fbd523185bad4689adc052940f41a8308L12-R12): Updated to use `TextHandler` class and modified type definitions accordingly. [[1]](diffhunk://#diff-707b0f8455353358a18744406669218fbd523185bad4689adc052940f41a8308L12-R12) [[2]](diffhunk://#diff-707b0f8455353358a18744406669218fbd523185bad4689adc052940f41a8308L21-R21) [[3]](diffhunk://#diff-707b0f8455353358a18744406669218fbd523185bad4689adc052940f41a8308L50-R54)