### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.3` to `v0.1.0-canary.4` (`prerelease`)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-canary.3"
+  "version": "0.1.0-canary.4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-plugin-mark",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "workspaces": [
         ".",
         "packages/*",
@@ -20,7 +20,7 @@
         "editorconfig-checker": "^6.0.0",
         "eslint": "^9.23.0",
         "eslint-config-bananass": "^0.0.7",
-        "eslint-plugin-mark": "^0.1.0-canary.3",
+        "eslint-plugin-mark": "^0.1.0-canary.4",
         "husky": "^9.1.5",
         "lerna": "8.1.9",
         "lint-staged": "^15.5.0",
@@ -20377,7 +20377,7 @@
       }
     },
     "packages/eslint-plugin-mark": {
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^6.3.0",
@@ -20410,18 +20410,18 @@
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "devDependencies": {
-        "eslint-plugin-mark": "^0.1.0-canary.3"
+        "eslint-plugin-mark": "^0.1.0-canary.4"
       }
     },
     "website": {
-      "version": "0.1.0-canary.3",
+      "version": "0.1.0-canary.4",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
         "@shikijs/transformers": "^3.2.2",
         "bananass-utils-vitepress": "^0.0.0",
-        "eslint-plugin-mark": "^0.1.0-canary.3",
+        "eslint-plugin-mark": "^0.1.0-canary.4",
         "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "vitepress": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": ">=20.18.0"
@@ -43,7 +43,7 @@
     "editorconfig-checker": "^6.0.0",
     "eslint": "^9.23.0",
     "eslint-config-bananass": "^0.0.7",
-    "eslint-plugin-mark": "^0.1.0-canary.3",
+    "eslint-plugin-mark": "^0.1.0-canary.4",
     "husky": "^9.1.5",
     "lerna": "8.1.9",
     "lint-staged": "^15.5.0",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mark",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "eslint-plugin-mark": "^0.1.0-canary.3"
+    "eslint-plugin-mark": "^0.1.0-canary.4"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "0.1.0-canary.3",
+  "version": "0.1.0-canary.4",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -12,7 +12,7 @@
     "@codecov/vite-plugin": "^1.9.0",
     "@shikijs/transformers": "^3.2.2",
     "bananass-utils-vitepress": "^0.0.0",
-    "eslint-plugin-mark": "^0.1.0-canary.3",
+    "eslint-plugin-mark": "^0.1.0-canary.4",
     "is-interactive": "^2.0.0",
     "markdown-it-footnote": "^4.0.0",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.4`

New release of `lumirlumir/npm-eslint-plugin-mark` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.3` to `v0.1.0-canary.4` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-eslint-plugin-mark/actions/runs/14426624592) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-plugin-mark` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | 129229a       |
| Old Version | `v0.1.0-canary.3`  |
| New Version | `v0.1.0-canary.4`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* refactor(eslint-plugin-mark)!: update exports field and rule tester helper function by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/69
### :sparkles: Features
* feat(eslint-plugin-mark): create `no-control-character` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/60
* feat(eslint-plugin-mark): create `en-capitalization` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/63
* feat(eslint-plugin-mark): create `allowed-heading` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/66
* feat(eslint-plugin-mark): create `image-title` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/67
### :recycle: Code Refactoring
* refactor(eslint-plugin-mark): cleanup `core`  by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/68
* refactor(eslint-plugin-mark): redesign `text-handler` class by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/70
### :arrow_up: Dependency Updates
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.3.8 to 1.4.1 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/61
* chore(deps-dev): bump @shikijs/transformers from 3.2.1 to 3.2.2 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/64


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-plugin-mark/compare/v0.1.0-canary.3...v0.1.0-canary.4