### PR TITLE
feat(eslint-plugin-mark): create `no-unused-definition` rule

### DIFF
--- a/packages/eslint-plugin-mark/src/configs/all.js
+++ b/packages/eslint-plugin-mark/src/configs/all.js
@@ -46,7 +46,7 @@ export default function all(parserMode) {
       'mark/no-git-conflict-marker': 'error',
       'mark/no-irregular-dash': 'error',
       'mark/no-irregular-whitespace': 'error',
-      'makr/no-unused-definition': 'error',
+      'mark/no-unused-definition': 'error',
     },
   };
 }

--- a/packages/eslint-plugin-mark/src/configs/all.js
+++ b/packages/eslint-plugin-mark/src/configs/all.js
@@ -46,6 +46,7 @@ export default function all(parserMode) {
       'mark/no-git-conflict-marker': 'error',
       'mark/no-irregular-dash': 'error',
       'mark/no-irregular-whitespace': 'error',
+      'makr/no-unused-definition': 'error',
     },
   };
 }

--- a/packages/eslint-plugin-mark/src/configs/recommended.js
+++ b/packages/eslint-plugin-mark/src/configs/recommended.js
@@ -42,6 +42,7 @@ export default function recommended(parserMode) {
       'mark/no-git-conflict-marker': 'error',
       'mark/no-irregular-dash': 'error',
       'mark/no-irregular-whitespace': 'error',
+      'mark/no-unused-definition': 'error',
     },
   };
 }

--- a/packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/reference-definition-handler.js
+++ b/packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/reference-definition-handler.js
@@ -68,6 +68,14 @@ export default class ReferenceDefinitionHandler {
   }
 
   /**
+   * Check if a `Definition` node is unused.
+   * @param {Definition} node
+   */
+  isUnusedDefinition(node) {
+    return !this.isImageDefinition(node) && !this.isLinkDefinition(node);
+  }
+
+  /**
    * Get all `Definition` nodes that are image definitions.
    */
   getImageDefinitions() {
@@ -79,6 +87,13 @@ export default class ReferenceDefinitionHandler {
    */
   getLinkDefinitions() {
     return this.#definitions.filter(def => this.isLinkDefinition(def));
+  }
+
+  /**
+   * Get all `Definition` nodes that are unused.
+   */
+  getUnusedDefinitions() {
+    return this.#definitions.filter(def => this.isUnusedDefinition(def));
   }
 
   // ------------------------------------------------------------------------------

--- a/packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/reference-definition-handler.test.js
+++ b/packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/reference-definition-handler.test.js
@@ -157,6 +157,26 @@ const definition3 = {
   },
 };
 
+const definition4 = {
+  type: 'definition',
+  identifier: 'unused',
+  label: 'unused',
+  title: null,
+  url: 'https://example.com/unused',
+  position: {
+    start: {
+      line: 14,
+      column: 1,
+      offset: 164,
+    },
+    end: {
+      line: 14,
+      column: 37,
+      offset: 200,
+    },
+  },
+};
+
 const refDefHandler = new ReferenceDefinitionHandler()
   .push(imageReference1)
   .push(imageReference2)
@@ -164,7 +184,8 @@ const refDefHandler = new ReferenceDefinitionHandler()
   .push(linkReference2)
   .push(definition1)
   .push(definition2)
-  .push(definition3);
+  .push(definition3)
+  .push(definition4);
 
 // --------------------------------------------------------------------------------
 // Test
@@ -175,7 +196,12 @@ describe(getFileName(import.meta.url), () => {
     it('should push nodes to the list correctly', () => {
       deepStrictEqual(refDefHandler.imageReferences, [imageReference1, imageReference2]);
       deepStrictEqual(refDefHandler.linkReferences, [linkReference1, linkReference2]);
-      deepStrictEqual(refDefHandler.definitions, [definition1, definition2, definition3]);
+      deepStrictEqual(refDefHandler.definitions, [
+        definition1,
+        definition2,
+        definition3,
+        definition4,
+      ]);
     });
   });
 
@@ -184,6 +210,7 @@ describe(getFileName(import.meta.url), () => {
       strictEqual(refDefHandler.isImageDefinition(definition1), true);
       strictEqual(refDefHandler.isImageDefinition(definition2), false);
       strictEqual(refDefHandler.isImageDefinition(definition3), true);
+      strictEqual(refDefHandler.isImageDefinition(definition4), false);
     });
   });
 
@@ -192,6 +219,16 @@ describe(getFileName(import.meta.url), () => {
       strictEqual(refDefHandler.isLinkDefinition(definition1), false);
       strictEqual(refDefHandler.isLinkDefinition(definition2), true);
       strictEqual(refDefHandler.isLinkDefinition(definition3), true);
+      strictEqual(refDefHandler.isLinkDefinition(definition4), false);
+    });
+  });
+
+  describe('isUnusedDefinition()', () => {
+    it('should return true for unused definitions', () => {
+      strictEqual(refDefHandler.isUnusedDefinition(definition1), false);
+      strictEqual(refDefHandler.isUnusedDefinition(definition2), false);
+      strictEqual(refDefHandler.isUnusedDefinition(definition3), false);
+      strictEqual(refDefHandler.isUnusedDefinition(definition4), true);
     });
   });
 
@@ -204,6 +241,12 @@ describe(getFileName(import.meta.url), () => {
   describe('getLinkDefinitions()', () => {
     it('should return link definitions', () => {
       deepStrictEqual(refDefHandler.getLinkDefinitions(), [definition2, definition3]);
+    });
+  });
+
+  describe('getUnusedDefinitions()', () => {
+    it('should return unused definitions', () => {
+      deepStrictEqual(refDefHandler.getUnusedDefinitions(), [definition4]);
     });
   });
 });

--- a/packages/eslint-plugin-mark/src/rules/index.js
+++ b/packages/eslint-plugin-mark/src/rules/index.js
@@ -14,6 +14,7 @@ import noEmoji from './no-emoji/index.js';
 import noGitConflictMarker from './no-git-conflict-marker/index.js';
 import noIrregularDash from './no-irregular-dash/index.js';
 import noIrregularWhitespace from './no-irregular-whitespace/index.js';
+import noUnusedDefinition from './no-unused-definition/index.js';
 
 export default {
   'allowed-heading': allowedHeading,
@@ -30,4 +31,5 @@ export default {
   'no-git-conflict-marker': noGitConflictMarker,
   'no-irregular-dash': noIrregularDash,
   'no-irregular-whitespace': noIrregularWhitespace,
+  'no-unused-definition': noUnusedDefinition,
 };

--- a/packages/eslint-plugin-mark/src/rules/no-unused-definition/index.js
+++ b/packages/eslint-plugin-mark/src/rules/no-unused-definition/index.js
@@ -1,0 +1,3 @@
+import noUnusedDefinition from './no-unused-definition.js';
+
+export default noUnusedDefinition;

--- a/packages/eslint-plugin-mark/src/rules/no-unused-definition/no-unused-definition.js
+++ b/packages/eslint-plugin-mark/src/rules/no-unused-definition/no-unused-definition.js
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview Rule to disallow unused definitions.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// TODO: Add options to ignore definition style comments.
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { ReferenceDefinitionHandler } from '../../core/ast/index.js';
+import { URL_RULE_DOCS } from '../../core/constants.js';
+
+// --------------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------------
+
+/**
+ * @typedef {import("@eslint/markdown").RuleModule} RuleModule
+ * @typedef {import("mdast").ImageReference} ImageReference
+ * @typedef {import("mdast").LinkReference} LinkReference
+ * @typedef {import("mdast").Definition} Definition
+ */
+
+// --------------------------------------------------------------------------------
+// Rule Definition
+// --------------------------------------------------------------------------------
+
+/** @type {RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      recommended: true,
+      description: 'Disallow unused definitions',
+      url: URL_RULE_DOCS('no-unused-definition'),
+    },
+
+    messages: {
+      noUnusedDefinition: 'Definition `{{ definition }}` is defined but never used.',
+    },
+
+    language: 'markdown',
+
+    dialects: ['commonmark', 'gfm'],
+  },
+
+  create(context) {
+    const refDefHandler = new ReferenceDefinitionHandler();
+
+    return {
+      /** @param {ImageReference} node */
+      imageReference(node) {
+        refDefHandler.push(node);
+      },
+
+      /** @param {LinkReference} node */
+      linkReference(node) {
+        refDefHandler.push(node);
+      },
+
+      /** @param {Definition} node */
+      definition(node) {
+        refDefHandler.push(node);
+      },
+
+      // TODO: Enable `'root:exit'()` syntax.
+      'root:exit': function () {
+        refDefHandler.getUnusedDefinitions().forEach(definition => {
+          context.report({
+            // @ts-expect-error -- TODO
+            node: definition,
+
+            data: {
+              definition: definition.identifier,
+            },
+
+            messageId: 'noUnusedDefinition',
+          });
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-mark/src/rules/no-unused-definition/no-unused-definition.test.js
+++ b/packages/eslint-plugin-mark/src/rules/no-unused-definition/no-unused-definition.test.js
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Test for `no-unused-definition.js`.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { getFileName, ruleTester } from '../../core/tests/index.js';
+import rule from './no-unused-definition.js';
+
+// --------------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------------
+
+const noUnusedDefinition = 'noUnusedDefinition';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+ruleTester(getFileName(import.meta.url), rule, {
+  valid: [
+    {
+      name: 'Empty',
+      code: '',
+    },
+    {
+      name: 'Empty string',
+      code: '  ',
+    },
+
+    {
+      name: 'Image reference full with definition',
+      code: '![foo][foo]\n\n[foo]: bar',
+    },
+    {
+      name: 'Image reference collapsed with definition',
+      code: '![foo][]\n\n[foo]: bar',
+    },
+    {
+      name: 'Image reference shortcut with definition',
+      code: '![foo]\n\n[foo]: bar',
+    },
+
+    {
+      name: 'Link reference full with definition',
+      code: '[foo][foo]\n\n[foo]: bar',
+    },
+    {
+      name: 'Link reference collapsed with definition',
+      code: '[foo][]\n\n[foo]: bar',
+    },
+    {
+      name: 'Link reference shortcut with definition',
+      code: '[foo]\n\n[foo]: bar',
+    },
+
+    {
+      name: 'Image and Link reference with definition',
+      code: '![foo][foo]\n\n[foo][foo]\n\n[foo]: bar',
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'Unused definition - 1',
+      code: '[foo]: bar',
+      errors: [
+        {
+          messageId: noUnusedDefinition,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 11,
+        },
+      ],
+    },
+    {
+      name: 'Unused definition - 2',
+      code: '[foo][foo]\n\n[bar]: baz',
+      errors: [
+        {
+          messageId: noUnusedDefinition,
+          line: 3,
+          column: 1,
+          endLine: 3,
+          endColumn: 11,
+        },
+      ],
+    },
+  ],
+});

--- a/website/docs/rules/no-unused-definition.md
+++ b/website/docs/rules/no-unused-definition.md
@@ -1,0 +1,62 @@
+<!-- markdownlint-disable-next-line no-inline-html first-line-h1 -->
+<header v-html="$frontmatter.rule"></header>
+
+## Rule Details
+
+This rule disallows unused reference definitions in Markdown documents. Reference definitions provide a way to create reusable links or images, but when they're defined but never referenced, they add unnecessary clutter to your document.
+
+The rule identifies definition entries (e.g., `[reference-id]: http://example.com`) that are not referenced by any link or image in the document and reports them as violations. Removing unused definitions helps keep your Markdown documents clean and maintainable.
+
+## Examples
+
+### :x: Incorrect
+
+Examples of **incorrect** code for this rule:
+
+```md
+This paragraph has no references to any definitions.
+
+[unused-link]: https://example.com
+[another-unused]: https://example.com/another "With title"
+```
+
+```md
+This paragraph references [some-link][used-link] but not all definitions.
+
+[used-link]: https://example.com
+[unused-link]: https://example.com/unused
+```
+
+### :white_check_mark: Correct
+
+Examples of **correct** code for this rule:
+
+```md
+This paragraph references [a link][used-link].
+
+[used-link]: https://example.com
+```
+
+```md
+This paragraph has an image ![Alt text][image-ref].
+
+[image-ref]: https://example.com/image.png "Image title"
+```
+
+## When Not To Use It
+
+You might want to disable this rule if:
+
+- You're maintaining a document with intentionally defined but temporarily unused references
+- You're using reference definitions as a form of documentation or note-taking
+- You have a workflow that automatically generates reference definitions, some of which might not be used in every document
+
+## AST
+
+This rule uses the `ReferenceDefinitionHandler` utility to track references and their definitions. It examines:
+
+- [`ImageReference`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#imagereference) nodes
+- [`LinkReference`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#linkreference) nodes
+- [`Definition`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#definition) nodes
+
+At the end of processing, it identifies any definition nodes that are never referenced by either image or link references.


### PR DESCRIPTION
This pull request introduces a new ESLint rule to disallow unused definitions in Markdown files, along with the necessary updates and tests to support this rule. The most important changes include adding the new rule, updating configurations, and adding tests to ensure proper functionality.

### New Rule Implementation:
* [`packages/eslint-plugin-mark/src/rules/no-unused-definition/no-unused-definition.js`](diffhunk://#diff-a68c103031b42bdebe1185b288e6809007ee6df9abcf44627389ec7fa10b9f91R1-R86): Introduced the `no-unused-definition` rule to disallow unused definitions in Markdown files.
* [`packages/eslint-plugin-mark/src/rules/no-unused-definition/index.js`](diffhunk://#diff-b7f373fb11041c71716bea9273d123259ce931faf5a61a52bd3dba28eaa9ce0dR1-R3): Exported the new `no-unused-definition` rule.

### Configuration Updates:
* [`packages/eslint-plugin-mark/src/configs/all.js`](diffhunk://#diff-dcdf50541cdda584e7b5e20419349e2a8760d86d4d140d12dbd1d97b3084703fR49): Added `mark/no-unused-definition` to the `all` configuration.
* [`packages/eslint-plugin-mark/src/configs/recommended.js`](diffhunk://#diff-5c2e62dd777b6828656ee264af3302d295f3768516f0cf7dfdbaa939848a0c01R45): Added `mark/no-unused-definition` to the `recommended` configuration.
* [`packages/eslint-plugin-mark/src/rules/index.js`](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R17): Included `no-unused-definition` in the list of exported rules. [[1]](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R17) [[2]](diffhunk://#diff-8bd6342bada2eb43bbaea244fd51588f57f5ec17967476e31bbf0408aaa82ed1R34)

### Core Handler Enhancements:
* [`packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/reference-definition-handler.js`](diffhunk://#diff-2cf29dc4c4fd262e7731a7f94a4adc13d41f8d0b20de6d11182fe8f28fd70ac9R70-R77): Added methods `isUnusedDefinition` and `getUnusedDefinitions` to identify unused definitions. [[1]](diffhunk://#diff-2cf29dc4c4fd262e7731a7f94a4adc13d41f8d0b20de6d11182fe8f28fd70ac9R70-R77) [[2]](diffhunk://#diff-2cf29dc4c4fd262e7731a7f94a4adc13d41f8d0b20de6d11182fe8f28fd70ac9R92-R98)

### Testing:
* [`packages/eslint-plugin-mark/src/rules/no-unused-definition/no-unused-definition.test.js`](diffhunk://#diff-a9370151610a6864f2bc60739ce2523734bb9b8ef123c07eabed36fe86c980bcR1-R94): Added tests for the `no-unused-definition` rule to ensure it correctly identifies unused definitions.
* [`packages/eslint-plugin-mark/src/core/ast/reference-definition-handler/reference-definition-handler.test.js`](diffhunk://#diff-a97345337fd90d8ecada50b9e540f3d3158d23c6332e125aaf7a6bcd17305c98R160-R188): Updated tests to include scenarios for unused definitions. [[1]](diffhunk://#diff-a97345337fd90d8ecada50b9e540f3d3158d23c6332e125aaf7a6bcd17305c98R160-R188) [[2]](diffhunk://#diff-a97345337fd90d8ecada50b9e540f3d3158d23c6332e125aaf7a6bcd17305c98L178-R204) [[3]](diffhunk://#diff-a97345337fd90d8ecada50b9e540f3d3158d23c6332e125aaf7a6bcd17305c98R213) [[4]](diffhunk://#diff-a97345337fd90d8ecada50b9e540f3d3158d23c6332e125aaf7a6bcd17305c98R222-R231) [[5]](diffhunk://#diff-a97345337fd90d8ecada50b9e540f3d3158d23c6332e125aaf7a6bcd17305c98R246-R251)

### Documentation:
* [`website/docs/rules/no-unused-definition.md`](diffhunk://#diff-134d4c48d8ad6fdd04062efdca2fe4be7f7fe6e1ff2e3e3f9eb1d4d7a7edc36cR1-R62): Added documentation for the `no-unused-definition` rule, including rule details, examples, and when not to use it.