### PR TITLE
chore(deps-dev): bump eslint from 9.23.0 to 9.25.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "c8": "^10.1.3",
         "concurrently": "^9.0.0",
         "editorconfig-checker": "^6.0.1",
-        "eslint": "^9.23.0",
+        "eslint": "^9.25.0",
         "eslint-config-bananass": "^0.1.0-canary.2",
         "eslint-plugin-mark": "^0.1.0-canary.4",
         "husky": "^9.1.5",
@@ -1459,9 +1459,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1474,9 +1474,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.0.tgz",
-      "integrity": "sha512-yJLLmLexii32mGrhW29qvU3QBVTu0GUmEf/J4XsBtVhp4JkIUFN/BjWqTF63yRvGApIDpZm5fa97LtYtINmfeQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.1.tgz",
+      "integrity": "sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1520,9 +1520,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
-      "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
+      "version": "9.25.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.0.tgz",
+      "integrity": "sha512-iWhsUS8Wgxz9AXNfvfOPFSW4VfMXdVhp1hjkZVhXCrpgh/aLcc45rX6MPu+tIVUWDw0HfNwth7O28M1xDxNf9w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1938,12 +1938,12 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
-      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.12.0",
+        "@eslint/core": "^0.13.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -7412,20 +7412,20 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
-      "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
+      "version": "9.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.25.0.tgz",
+      "integrity": "sha512-MsBdObhM4cEwkzCiraDv7A6txFXEqtNXOb877TsSp2FCkBNl8JfVQrmiuDqC1IkejT6JLPzYBXx/xAiYhyzgGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.2",
-        "@eslint/config-helpers": "^0.2.0",
-        "@eslint/core": "^0.12.0",
+        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.13.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.23.0",
-        "@eslint/plugin-kit": "^0.2.7",
+        "@eslint/js": "9.25.0",
+        "@eslint/plugin-kit": "^0.2.8",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -20284,7 +20284,7 @@
       },
       "devDependencies": {
         "@types/mdast": "^4.0.4",
-        "eslint": "^9.23.0"
+        "eslint": "^9.25.0"
       },
       "peerDependencies": {
         "eslint": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "c8": "^10.1.3",
     "concurrently": "^9.0.0",
     "editorconfig-checker": "^6.0.1",
-    "eslint": "^9.23.0",
+    "eslint": "^9.25.0",
     "eslint-config-bananass": "^0.1.0-canary.2",
     "eslint-plugin-mark": "^0.1.0-canary.4",
     "husky": "^9.1.5",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -88,6 +88,6 @@
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4",
-    "eslint": "^9.23.0"
+    "eslint": "^9.25.0"
   }
 }


### PR DESCRIPTION
This pull request updates the `eslint` dependency to a newer version in two `package.json` files.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L45-R45): Updated `eslint` from version `^9.23.0` to `^9.25.0`.
* [`packages/eslint-plugin-mark/package.json`](diffhunk://#diff-9b9400561d26b4f60200e53b8fbb54b0ef18955f8348a54f396c6ac386667a0dL91-R91): Updated `eslint` from version `^9.23.0` to `^9.25.0`.