### PR TITLE
feat(eslint-plugin-mark): add support for YAML Front Matter parsing by default

### DIFF
--- a/packages/eslint-plugin-mark/src/configs/base.js
+++ b/packages/eslint-plugin-mark/src/configs/base.js
@@ -36,6 +36,9 @@ export default function base(parserMode) {
       markdown,
       mark: { rules },
     },
+    languageOptions: {
+      frontmatter: 'yaml',
+    },
     language: `markdown/${parserMode}`,
   };
 }


### PR DESCRIPTION
This pull request introduces a small enhancement to the `base` function in the `eslint-plugin-mark` package. The change adds support for specifying frontmatter language options.

* [`packages/eslint-plugin-mark/src/configs/base.js`](diffhunk://#diff-ca6e352859484792fa1631527eb0aea682ea1b33b962674c8fe86ecb09edf0d5R39-R41): Added a `languageOptions` property to define `frontmatter` as `yaml` in the `base` function.