### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.4` to `v0.1.0-canary.5` (`prerelease`)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-canary.4"
+  "version": "0.1.0-canary.5"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.4",
+  "version": "0.1.0-canary.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-plugin-mark",
-      "version": "0.1.0-canary.4",
+      "version": "0.1.0-canary.5",
       "workspaces": [
         ".",
         "packages/*",
@@ -20,7 +20,7 @@
         "editorconfig-checker": "^6.0.1",
         "eslint": "^9.25.1",
         "eslint-config-bananass": "^0.1.0-canary.4",
-        "eslint-plugin-mark": "^0.1.0-canary.4",
+        "eslint-plugin-mark": "^0.1.0-canary.5",
         "husky": "^9.1.5",
         "lerna": "^8.2.2",
         "lint-staged": "^15.5.1",
@@ -20275,7 +20275,7 @@
       }
     },
     "packages/eslint-plugin-mark": {
-      "version": "0.1.0-canary.4",
+      "version": "0.1.0-canary.5",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^6.4.0",
@@ -20308,18 +20308,18 @@
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.1.0-canary.4",
+      "version": "0.1.0-canary.5",
       "devDependencies": {
-        "eslint-plugin-mark": "^0.1.0-canary.4"
+        "eslint-plugin-mark": "^0.1.0-canary.5"
       }
     },
     "website": {
-      "version": "0.1.0-canary.4",
+      "version": "0.1.0-canary.5",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
         "@shikijs/transformers": "^3.3.0",
         "bananass-utils-vitepress": "^0.0.0",
-        "eslint-plugin-mark": "^0.1.0-canary.4",
+        "eslint-plugin-mark": "^0.1.0-canary.5",
         "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "vitepress": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.4",
+  "version": "0.1.0-canary.5",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": ">=20.18.0"
@@ -44,7 +44,7 @@
     "editorconfig-checker": "^6.0.1",
     "eslint": "^9.25.1",
     "eslint-config-bananass": "^0.1.0-canary.4",
-    "eslint-plugin-mark": "^0.1.0-canary.4",
+    "eslint-plugin-mark": "^0.1.0-canary.5",
     "husky": "^9.1.5",
     "lerna": "^8.2.2",
     "lint-staged": "^15.5.1",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mark",
-  "version": "0.1.0-canary.4",
+  "version": "0.1.0-canary.5",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.1.0-canary.4",
+  "version": "0.1.0-canary.5",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "eslint-plugin-mark": "^0.1.0-canary.4"
+    "eslint-plugin-mark": "^0.1.0-canary.5"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "0.1.0-canary.4",
+  "version": "0.1.0-canary.5",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -12,7 +12,7 @@
     "@codecov/vite-plugin": "^1.9.0",
     "@shikijs/transformers": "^3.3.0",
     "bananass-utils-vitepress": "^0.0.0",
-    "eslint-plugin-mark": "^0.1.0-canary.4",
+    "eslint-plugin-mark": "^0.1.0-canary.5",
     "is-interactive": "^2.0.0",
     "markdown-it-footnote": "^4.0.0",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.5`

New release of `lumirlumir/npm-eslint-plugin-mark` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.4` to `v0.1.0-canary.5` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-eslint-plugin-mark/actions/runs/14730350032) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-plugin-mark` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | 53c4e2f       |
| Old Version | `v0.1.0-canary.4`  |
| New Version | `v0.1.0-canary.5`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(eslint-plugin-mark): create `no-unused-definition` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/72
* feat(eslint-plugin-mark): add support for YAML Front Matter parsing by default by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/92
### :toolbox: Chores
* chore(sync-server): update lint configs and bump package versions by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/76
* chore(sync-server): update `lint-staged` and scripts by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/79
### :recycle: Code Refactoring
* refactor(eslint-plugin-mark): update types and bump @eslint/markdown from 6.3.0 to 6.4.0 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/80
### :arrow_up: Dependency Updates
* chore(deps-dev): bump lint-staged from 15.5.0 to 15.5.1 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/73
* chore(deps-dev): bump textlint-rule-allowed-uris from 1.0.9 to 1.1.0 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/74
* chore(deps-dev): bump @types/node from 22.14.0 to 22.14.1 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/75
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.4.1 to 1.5.2 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/77
* chore(deps-dev): bump eslint from 9.23.0 to 9.25.0 by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/82
* chore(deps-dev): bump @shikijs/transformers from 3.2.2 to 3.3.0 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/85
* chore(deps-dev): bump eslint from 9.25.0 to 9.25.1 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/83
* chore(deps-dev): bump @types/node from 22.14.1 to 22.15.0 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/88
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/87
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/89
* chore(deps-dev): bump @types/node from 22.15.0 to 22.15.3 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/91


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-plugin-mark/compare/v0.1.0-canary.4...v0.1.0-canary.5