### PR TITLE
chore(*): update ESLint configurations

### DIFF
--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -68,8 +68,6 @@ lumirlumir/lumirlumir-configs:
     dest: ./configs/LICENSE.md
   - source: ./VScode.code-workspace
     dest: ./configs/VScode.code-workspace
-  - source: ./eslint.config.mjs
-    dest: ./configs/eslint.config.mjs
   - source: ./lint-staged.config.mjs
     dest: ./configs/lint-staged.config.mjs
   - source: ./prettier.config.mjs

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,9 @@
+import { defineConfig } from 'eslint/config';
 import bananass from 'eslint-config-bananass';
 import mark from 'eslint-plugin-mark';
 
 /** @type {import("eslint").Linter.Config[]} */
-export default [
+export default defineConfig([
   {
     name: 'global/ignores',
     ignores: ['**/build/', '**/coverage/', '**/.vitepress/cache/'],
@@ -10,4 +11,26 @@ export default [
   bananass.configs.js,
   bananass.configs.ts,
   mark.configs.recommendedGfm,
-];
+  {
+    name: 'website/rules',
+    files: ['website/docs/rules/**/*.md'],
+    rules: {
+      'mark/allowed-heading': [
+        'error',
+        {
+          h2: [
+            'Rule Details',
+            'Examples',
+            'Options',
+            'When Not To Use It',
+            'AST',
+            'Fix',
+            'Limitations',
+            'Prior Art',
+          ],
+        },
+      ],
+      'mark/no-emoji': 'error',
+    },
+  },
+]);

--- a/website/docs/rules/no-irregular-whitespace.md
+++ b/website/docs/rules/no-irregular-whitespace.md
@@ -1,6 +1,7 @@
 <!-- markdownlint-disable-next-line no-inline-html first-line-h1 -->
 <header v-html="$frontmatter.rule"></header>
 
+<!-- eslint-disable-next-line -- TODO -->
 ## Overview
 
 Invalid or irregular whitespace can cause issues with Markdown parsers and also makes code harder to debug in a similar nature to mixed tabs and spaces.


### PR DESCRIPTION
This pull request includes updates to the ESLint configuration, removal of unused files from the sync configuration, and a minor documentation change. The most significant changes involve restructuring the ESLint configuration using `defineConfig` and adding new rules for Markdown files.

### ESLint Configuration Updates:
* [`eslint.config.mjs`](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R1-R36): Replaced the default export with `defineConfig` for better readability and structure. Added a new configuration block (`website/rules`) for Markdown files, including rules for allowed headings and disallowing emojis.

### Sync Configuration Updates:
* [`.github/sync-client.yml`](diffhunk://#diff-93bc202766315b6269beef308a6ad30ed3e86938ddbfa31b49e030f2263695f1L71-L72): Removed the `eslint.config.mjs` file from the sync configuration, as it is no longer being synced to the `configs` directory.

### Documentation Updates:
* [`website/docs/rules/no-irregular-whitespace.md`](diffhunk://#diff-1b6362b81ab627fb3d0e02f0c4d30ea6969217d8a171c7ad514695af6dc73536R4): Added a TODO comment to disable an ESLint rule inline, likely for further refinement or clarification.