### PR TITLE
fix(eslint-plugin-mark): enforce unique items in array options

### DIFF
--- a/packages/eslint-plugin-mark/src/rules/allowed-heading/allowed-heading.js
+++ b/packages/eslint-plugin-mark/src/rules/allowed-heading/allowed-heading.js
@@ -55,6 +55,7 @@ export default {
               {
                 type: 'array',
                 items: { type: 'string' },
+                uniqueItems: true,
               },
             ],
           },
@@ -66,6 +67,7 @@ export default {
               {
                 type: 'array',
                 items: { type: 'string' },
+                uniqueItems: true,
               },
             ],
           },
@@ -77,6 +79,7 @@ export default {
               {
                 type: 'array',
                 items: { type: 'string' },
+                uniqueItems: true,
               },
             ],
           },
@@ -88,6 +91,7 @@ export default {
               {
                 type: 'array',
                 items: { type: 'string' },
+                uniqueItems: true,
               },
             ],
           },
@@ -99,6 +103,7 @@ export default {
               {
                 type: 'array',
                 items: { type: 'string' },
+                uniqueItems: true,
               },
             ],
           },
@@ -110,6 +115,7 @@ export default {
               {
                 type: 'array',
                 items: { type: 'string' },
+                uniqueItems: true,
               },
             ],
           },

--- a/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js
+++ b/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js
@@ -127,6 +127,7 @@ export default {
             items: {
               enum: Object.keys(langShorthandMap),
             },
+            uniqueItems: true,
           },
           override: {
             type: 'object',

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
@@ -57,6 +57,7 @@ export default {
             items: {
               enum: [1, 2, 3, 4, 5, 6],
             },
+            uniqueItems: true,
           },
         },
         additionalProperties: false,


### PR DESCRIPTION
This pull request introduces a consistent improvement to the schema validation for several ESLint rules in the `eslint-plugin-mark` package by adding the `uniqueItems: true` property to array definitions. This ensures that arrays in the configuration will not allow duplicate entries, improving data integrity and reducing potential configuration errors.

### Schema Validation Enhancements:

* [`packages/eslint-plugin-mark/src/rules/allowed-heading/allowed-heading.js`](diffhunk://#diff-d5951c4773cae305a950c0c4cc9ccb7ae0edd097899fe6b6a095e19a15c7f34fR58): Added `uniqueItems: true` to six array definitions to ensure uniqueness in allowed heading configurations. [[1]](diffhunk://#diff-d5951c4773cae305a950c0c4cc9ccb7ae0edd097899fe6b6a095e19a15c7f34fR58) [[2]](diffhunk://#diff-d5951c4773cae305a950c0c4cc9ccb7ae0edd097899fe6b6a095e19a15c7f34fR70) [[3]](diffhunk://#diff-d5951c4773cae305a950c0c4cc9ccb7ae0edd097899fe6b6a095e19a15c7f34fR82) [[4]](diffhunk://#diff-d5951c4773cae305a950c0c4cc9ccb7ae0edd097899fe6b6a095e19a15c7f34fR94) [[5]](diffhunk://#diff-d5951c4773cae305a950c0c4cc9ccb7ae0edd097899fe6b6a095e19a15c7f34fR106) [[6]](diffhunk://#diff-d5951c4773cae305a950c0c4cc9ccb7ae0edd097899fe6b6a095e19a15c7f34fR118)
* [`packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js`](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bR130): Added `uniqueItems: true` to the array definition for language shorthand mappings, preventing duplicate entries.
* [`packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js`](diffhunk://#diff-64161e7614a45746324c8428c938fb2c11f1cf8d9f91d58b096a51ee7e13fb10R60): Added `uniqueItems: true` to the array definition for heading levels, ensuring no duplicates in the specified levels.