### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.5` to `v0.1.0-canary.6` (`prerelease`)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-canary.5"
+  "version": "0.1.0-canary.6"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-plugin-mark",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "workspaces": [
         ".",
         "packages/*",
@@ -20,7 +20,7 @@
         "editorconfig-checker": "^6.0.1",
         "eslint": "^9.27.0",
         "eslint-config-bananass": "^0.1.1",
-        "eslint-plugin-mark": "^0.1.0-canary.5",
+        "eslint-plugin-mark": "^0.1.0-canary.6",
         "husky": "^9.1.5",
         "lerna": "^8.2.2",
         "lint-staged": "^16.0.0",
@@ -20928,7 +20928,7 @@
       }
     },
     "packages/eslint-plugin-mark": {
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^6.4.0",
@@ -20961,19 +20961,19 @@
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
-        "eslint-plugin-mark": "^0.1.0-canary.5"
+        "eslint-plugin-mark": "^0.1.0-canary.6"
       }
     },
     "website": {
-      "version": "0.1.0-canary.5",
+      "version": "0.1.0-canary.6",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
         "@shikijs/transformers": "^3.4.2",
         "@shikijs/vitepress-twoslash": "^3.4.2",
         "bananass-utils-vitepress": "^0.1.1",
-        "eslint-plugin-mark": "^0.1.0-canary.5",
+        "eslint-plugin-mark": "^0.1.0-canary.6",
         "markdown-it-footnote": "^4.0.0",
         "twoslash-eslint": "^0.3.1",
         "vitepress": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": ">=20.18.0"
@@ -44,7 +44,7 @@
     "editorconfig-checker": "^6.0.1",
     "eslint": "^9.27.0",
     "eslint-config-bananass": "^0.1.1",
-    "eslint-plugin-mark": "^0.1.0-canary.5",
+    "eslint-plugin-mark": "^0.1.0-canary.6",
     "husky": "^9.1.5",
     "lerna": "^8.2.2",
     "lint-staged": "^16.0.0",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mark",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "eslint-plugin-mark": "^0.1.0-canary.5"
+    "eslint-plugin-mark": "^0.1.0-canary.6"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "0.1.0-canary.5",
+  "version": "0.1.0-canary.6",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -13,7 +13,7 @@
     "@shikijs/transformers": "^3.4.2",
     "@shikijs/vitepress-twoslash": "^3.4.2",
     "bananass-utils-vitepress": "^0.1.1",
-    "eslint-plugin-mark": "^0.1.0-canary.5",
+    "eslint-plugin-mark": "^0.1.0-canary.6",
     "markdown-it-footnote": "^4.0.0",
     "twoslash-eslint": "^0.3.1",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.6`

New release of `lumirlumir/npm-eslint-plugin-mark` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.5` to `v0.1.0-canary.6` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-eslint-plugin-mark/actions/runs/15239734886) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-plugin-mark` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | ed33f73       |
| Old Version | `v0.1.0-canary.5`  |
| New Version | `v0.1.0-canary.6`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(eslint-plugin-mark): enhance `allowed-heading` with detailed error message by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/134
### :bug: Bug Fixes
* fix(eslint-plugin-mark): enforce unique items in array options by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/132
### :toolbox: Chores
* chore(sync-server): update `dependabot.yml` and `.gitignore` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/99
* chore(sync-server): remove `is-interactive` dependency and update Codecov configuration by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/109
* chore(*): update ESLint configurations by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/115
* chore(sync-server): update `dependabot.yml` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/130
* chore(*): update README badge and ESLint config file by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/131
* chore(website): add support for twoslash by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/133
### :arrow_up: Dependency Updates
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/94
* chore(deps-dev): bump textlint from 14.6.0 to 14.7.1 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/95
* chore(deps-dev): bump @types/node from 22.15.3 to 22.15.10 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/98
* chore(deps-dev): bump eslint from 9.25.1 to 9.26.0 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/96
* chore(deps-dev): bump @types/node from 22.15.10 to 22.15.17 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/105
* chore(deps-dev): bump lint-staged from 15.5.1 to 15.5.2 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/102
* chore(deps-dev): bump lint-staged from 15.5.2 to 16.0.0 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/107
* chore(deps-dev): bump the bananass group across 1 directory with 3 updates by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/108
* chore(deps-dev): bump @shikijs/transformers from 3.3.0 to 3.4.1 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/110
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.5.2 to 1.5.5 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/117
* chore(deps): bump undici from 6.21.1 to 6.21.3 in the npm_and_yarn group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/116
* chore(deps-dev): bump @types/node from 22.15.17 to 22.15.18 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/112
* chore(deps-dev): bump eslint from 9.26.0 to 9.27.0 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/121
* chore(deps-dev): bump @types/node from 22.15.18 to 22.15.19 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/120
* chore(deps-dev): bump @shikijs/transformers from 3.4.1 to 3.4.2 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/119
* chore(deps-dev): bump markdownlint-cli from 0.44.0 to 0.45.0 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/124
* chore(deps-dev): bump @codecov/vite-plugin from 1.9.0 to 1.9.1 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/125
* chore(deps-dev): bump textlint from 14.7.1 to 14.7.2 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/128
* chore(deps-dev): bump the bananass group across 2 directories with 3 updates by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/127
* chore(deps-dev): bump @types/node from 22.15.19 to 22.15.21 by @dependabot in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/129


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-plugin-mark/compare/v0.1.0-canary.5...v0.1.0-canary.6