### PR TITLE
chore(deps-dev): bump `textlint-rule-allowed-uris`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
         "markdownlint-cli": "^0.45.0",
         "prettier": "^3.6.2",
         "prettier-config-bananass": "^0.3.1",
-        "textlint": "^14.7.2",
-        "textlint-rule-allowed-uris": "^2.0.0",
+        "textlint": "14.7.2",
+        "textlint-rule-allowed-uris": "^2.0.1",
         "typescript": "^5.9.2"
       },
       "engines": {
@@ -671,20 +671,20 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.1.tgz",
-      "integrity": "sha512-4JFstCTaToCFrPqrGzgkF8N2NHjtsaY4uRh6brZQ5L9e4wbMieX8oDT8N7qfVFTQecHFEtkj4ve49VIZ3mKVqw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
+      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@emnapi/wasi-threads": "1.0.1",
+        "@emnapi/wasi-threads": "1.0.4",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.1.tgz",
-      "integrity": "sha512-LMshMVP0ZhACNjQNYXiU1iZJ6QCcv0lUdPDPugqGvCGXt5xtRVBPdtA0qU12pEXZzpWAhWlZYptfdAFq10DOVQ==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.1.tgz",
-      "integrity": "sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2074,9 +2074,9 @@
       "license": "MIT"
     },
     "node_modules/@lerna/create": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.2.2.tgz",
-      "integrity": "sha512-1yn1MvWn2Yz0SFgTTQnef2m1YedF7KwqLLVIOrGkgQrkVHzsveAIk1A1RcRa2yyUh+siKI1YcJ7lUZIEt+qQ3Q==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.2.4.tgz",
+      "integrity": "sha512-A8AlzetnS2WIuhijdAzKUyFpR5YbLLfV3luQ4lzBgIBgRfuoBDZeF+RSZPhra+7A6/zTUlrbhKZIOi/MNhqgvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2103,7 +2103,6 @@
         "get-stream": "6.0.0",
         "git-url-parse": "14.0.0",
         "glob-parent": "6.0.2",
-        "globby": "11.1.0",
         "graceful-fs": "4.2.11",
         "has-unicode": "2.0.1",
         "ini": "^1.3.8",
@@ -2114,7 +2113,6 @@
         "js-yaml": "4.1.0",
         "libnpmpublish": "9.0.9",
         "load-json-file": "6.2.0",
-        "lodash": "^4.17.21",
         "make-dir": "4.0.0",
         "minimatch": "3.0.5",
         "multimatch": "5.0.0",
@@ -2138,9 +2136,10 @@
         "slash": "^3.0.0",
         "ssri": "^10.0.6",
         "string-width": "^4.2.3",
-        "strong-log-transformer": "2.1.0",
         "tar": "6.2.1",
         "temp-dir": "1.0.0",
+        "through": "2.3.8",
+        "tinyglobby": "0.2.12",
         "upath": "2.0.1",
         "uuid": "^10.0.0",
         "validate-npm-package-license": "^3.0.4",
@@ -2172,6 +2171,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@lerna/create/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@lerna/create/node_modules/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
@@ -2183,6 +2197,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@lerna/create/node_modules/resolve-from": {
@@ -2213,6 +2240,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/tinyglobby": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2681,9 +2725,9 @@
       }
     },
     "node_modules/@nx/devkit": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.8.0.tgz",
-      "integrity": "sha512-0616zW0Krwb5frNZ7C0HUItonCDiAHY9UYSTyJm6hnal0Xc6XkJuEAFNjbx2sEOopO85CEAMNeYEHkRyWsSxCQ==",
+      "version": "20.8.2",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.8.2.tgz",
+      "integrity": "sha512-rr9p2/tZDQivIpuBUpZaFBK6bZ+b5SAjZk75V4tbCUqGW3+5OPuVvBPm+X+7PYwUF6rwSpewxkjWNeGskfCe+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2727,9 +2771,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.8.0.tgz",
-      "integrity": "sha512-A6Te2KlINtcOo/depXJzPyjbk9E0cmgbom/sm/49XdQ8G94aDfyIIY1RIdwmDCK5NVd74KFG3JIByTk5+VnAhA==",
+      "version": "20.8.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.8.2.tgz",
+      "integrity": "sha512-t+bmCn6sRPNGU6hnSyWNvbQYA/KgsxGZKYlaCLRwkNhI2akModcBUqtktJzCKd1XHDqs6EkEFBWjFr8/kBEkSg==",
       "cpu": [
         "arm64"
       ],
@@ -2744,9 +2788,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.8.0.tgz",
-      "integrity": "sha512-UpqayUjgalArXaDvOoshqSelTrEp42cGDsZGy0sqpxwBpm3oPQ8wE1d7oBAmRo208rAxOuFP0LZRFUqRrwGvLA==",
+      "version": "20.8.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.8.2.tgz",
+      "integrity": "sha512-pt/wmDLM31Es8/EzazlyT5U+ou2l60rfMNFGCLqleHEQ0JUTc0KWnOciBLbHIQFiPsCQZJFEKyfV5V/ncePmmw==",
       "cpu": [
         "x64"
       ],
@@ -2761,9 +2805,9 @@
       }
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.8.0.tgz",
-      "integrity": "sha512-dUR2fsLyKZYMHByvjy2zvmdMbsdXAiP+6uTlIAuu8eHMZ2FPQCAtt7lPYLwOFUxUXChbek2AJ+uCI0gRAgK/eg==",
+      "version": "20.8.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.8.2.tgz",
+      "integrity": "sha512-joZxFbgJfkHkB9uMIJr73Gpnm9pnpvr0XKGbWC409/d2x7q1qK77tKdyhGm+A3+kaZFwstNVPmCUtUwJYyU6LA==",
       "cpu": [
         "x64"
       ],
@@ -2778,9 +2822,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.8.0.tgz",
-      "integrity": "sha512-GuZ7t0SzSX5ksLYva7koKZovQ5h/Kr1pFbOsQcBf3VLREBqFPSz6t7CVYpsIsMhiu/I3EKq6FZI3wDOJbee5uw==",
+      "version": "20.8.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.8.2.tgz",
+      "integrity": "sha512-98O/qsxn4vIMPY/FyzvmVrl7C5yFhCUVk0/4PF+PA2SvtQ051L1eMRY6bq/lb69qfN6szJPZ41PG5mPx0NeLZw==",
       "cpu": [
         "arm"
       ],
@@ -2795,9 +2839,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.8.0.tgz",
-      "integrity": "sha512-CiI955Q+XZmBBZ7cQqQg0MhGEFwZIgSpJnjPfWBt3iOYP8aE6nZpNOkmD7O8XcN/nEwwyeCOF8euXqEStwsk8w==",
+      "version": "20.8.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.8.2.tgz",
+      "integrity": "sha512-h6a+HxwfSpxsi4KpxGgPh9GDBmD2E+XqGCdfYpobabxqEBvlnIlJyuDhlRR06cTWpuNXHpRdrVogmV6m/YbtDg==",
       "cpu": [
         "arm64"
       ],
@@ -2812,9 +2856,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.8.0.tgz",
-      "integrity": "sha512-Iy9DpvVisxsfNh4gOinmMQ4cLWdBlgvt1wmry1UwvcXg479p1oJQ1Kp1wksUZoWYqrAG8VPZUmkE0f7gjyHTGg==",
+      "version": "20.8.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.8.2.tgz",
+      "integrity": "sha512-4Ev+jM0VAxDHV/dFgMXjQTCXS4I8W4oMe7FSkXpG8RUn6JK659DC8ExIDPoGIh+Cyqq6r6mw1CSia+ciQWICWQ==",
       "cpu": [
         "arm64"
       ],
@@ -2829,9 +2873,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.8.0.tgz",
-      "integrity": "sha512-kZrrXXzVSbqwmdTmQ9xL4Jhi0/FSLrePSxYCL9oOM3Rsj0lmo/aC9kz4NBv1ZzuqT7fumpBOnhqiL1QyhOWOeQ==",
+      "version": "20.8.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.8.2.tgz",
+      "integrity": "sha512-nR0ev+wxu+nQYRd7bhqggOxK7UfkV6h+Ko1mumUFyrM5GvPpz/ELhjJFSnMcOkOMcvH0b6G5uTBJvN1XWCkbmg==",
       "cpu": [
         "x64"
       ],
@@ -2846,9 +2890,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.8.0.tgz",
-      "integrity": "sha512-0l9jEMN8NhULKYCFiDF7QVpMMNG40duya+OF8dH0OzFj52N0zTsvsgLY72TIhslCB/cC74oAzsmWEIiFslscnA==",
+      "version": "20.8.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.8.2.tgz",
+      "integrity": "sha512-ost41l5yc2aq2Gc9bMMpaPi/jkXqbXEMEPHrxWKuKmaek3K2zbVDQzvBBNcQKxf/mlCsrqN4QO0mKYSRRqag5A==",
       "cpu": [
         "x64"
       ],
@@ -2863,9 +2907,9 @@
       }
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.8.0.tgz",
-      "integrity": "sha512-5miZJmRSwx1jybBsiB3NGocXL9TxGdT2D+dOqR2fsLklpGz0ItEWm8+i8lhDjgOdAr2nFcuQUfQMY57f9FOHrA==",
+      "version": "20.8.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.8.2.tgz",
+      "integrity": "sha512-0SEOqT/daBG5WtM9vOGilrYaAuf1tiALdrFavY62+/arXYxXemUKmRI5qoKDTnvoLMBGkJs6kxhMO5b7aUXIvQ==",
       "cpu": [
         "arm64"
       ],
@@ -2880,9 +2924,9 @@
       }
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.8.0.tgz",
-      "integrity": "sha512-0P5r+bDuSNvoWys+6C1/KqGpYlqwSHpigCcyRzR62iZpT3OooZv+nWO06RlURkxMR8LNvYXTSSLvoLkjxqM8uQ==",
+      "version": "20.8.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.8.2.tgz",
+      "integrity": "sha512-iIsY+tVqes/NOqTbJmggL9Juie/iaDYlWgXA9IUv88FE9thqWKhVj4/tCcPjsOwzD+1SVna3YISEEFsx5UV4ew==",
       "cpu": [
         "x64"
       ],
@@ -5549,9 +5593,9 @@
       }
     },
     "node_modules/cacheable/node_modules/keyv": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.4.0.tgz",
-      "integrity": "sha512-TMckyVjEoacG5IteUpUrOBsFORtheqziVyyY2dLUwg1jwTb8u48LX4TgmtogkNl9Y9unaEJ1luj10fGyjMGFOQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.0.tgz",
+      "integrity": "sha512-QG7qR2tijh1ftOvClut4YKKg1iW6cx3GZsKoGyJPxHkGWK9oJhG9P3j5deP0QQOGDowBMVQFaP+Vm4NpGYvmIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6804,19 +6848,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -6942,13 +6973,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -7055,9 +7079,9 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8637,9 +8661,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9151,27 +9175,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globrex": {
@@ -10543,16 +10546,15 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
+        "async": "^3.2.6",
         "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "jake": "bin/cli.js"
@@ -10857,13 +10859,13 @@
       }
     },
     "node_modules/lerna": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.2.2.tgz",
-      "integrity": "sha512-GkqBELTG4k7rfzAwRok2pKBvhNo046Hfwcj7TuhDah3q58/BBBAqvIFLfqEI5fglnNOs6maMSn6/MWjccQE55A==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.2.4.tgz",
+      "integrity": "sha512-0gaVWDIVT7fLfprfwpYcQajb7dBJv3EGavjG7zvJ+TmGx3/wovl5GklnSwM2/WeE0Z2wrIz7ndWhBcDUHVjOcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lerna/create": "8.2.2",
+        "@lerna/create": "8.2.4",
         "@npmcli/arborist": "7.5.4",
         "@npmcli/package-json": "5.2.0",
         "@npmcli/run-script": "8.1.0",
@@ -10890,7 +10892,6 @@
         "get-stream": "6.0.0",
         "git-url-parse": "14.0.0",
         "glob-parent": "6.0.2",
-        "globby": "11.1.0",
         "graceful-fs": "4.2.11",
         "has-unicode": "2.0.1",
         "import-local": "3.1.0",
@@ -10904,7 +10905,6 @@
         "libnpmaccess": "8.0.6",
         "libnpmpublish": "9.0.9",
         "load-json-file": "6.2.0",
-        "lodash": "^4.17.21",
         "make-dir": "4.0.0",
         "minimatch": "3.0.5",
         "multimatch": "5.0.0",
@@ -10930,9 +10930,10 @@
         "slash": "3.0.0",
         "ssri": "^10.0.6",
         "string-width": "^4.2.3",
-        "strong-log-transformer": "2.1.0",
         "tar": "6.2.1",
         "temp-dir": "1.0.0",
+        "through": "2.3.8",
+        "tinyglobby": "0.2.12",
         "typescript": ">=3 < 6",
         "upath": "2.0.1",
         "uuid": "^10.0.0",
@@ -10968,6 +10969,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/lerna/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/lerna/node_modules/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
@@ -10979,6 +10995,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/lerna/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/lerna/node_modules/resolve-from": {
@@ -11009,6 +11038,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/lerna/node_modules/tinyglobby": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/levn": {
@@ -11136,9 +11182,9 @@
       }
     },
     "node_modules/lint-staged/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
+      "integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14867,9 +14913,9 @@
       }
     },
     "node_modules/nx": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-20.8.0.tgz",
-      "integrity": "sha512-+BN5B5DFBB5WswD8flDDTnr4/bf1VTySXOv60aUAllHqR+KS6deT0p70TTMZF4/A2n/L2UCWDaDro37MGaYozA==",
+      "version": "20.8.2",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-20.8.2.tgz",
+      "integrity": "sha512-mDKpbH3vEpUFDx0rrLh+tTqLq1PYU8KiD/R7OVZGd1FxQxghx2HOl32MiqNsfPcw6AvKlXhslbwIESV+N55FLQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -14914,16 +14960,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "20.8.0",
-        "@nx/nx-darwin-x64": "20.8.0",
-        "@nx/nx-freebsd-x64": "20.8.0",
-        "@nx/nx-linux-arm-gnueabihf": "20.8.0",
-        "@nx/nx-linux-arm64-gnu": "20.8.0",
-        "@nx/nx-linux-arm64-musl": "20.8.0",
-        "@nx/nx-linux-x64-gnu": "20.8.0",
-        "@nx/nx-linux-x64-musl": "20.8.0",
-        "@nx/nx-win32-arm64-msvc": "20.8.0",
-        "@nx/nx-win32-x64-msvc": "20.8.0"
+        "@nx/nx-darwin-arm64": "20.8.2",
+        "@nx/nx-darwin-x64": "20.8.2",
+        "@nx/nx-freebsd-x64": "20.8.2",
+        "@nx/nx-linux-arm-gnueabihf": "20.8.2",
+        "@nx/nx-linux-arm64-gnu": "20.8.2",
+        "@nx/nx-linux-arm64-musl": "20.8.2",
+        "@nx/nx-linux-x64-gnu": "20.8.2",
+        "@nx/nx-linux-x64-musl": "20.8.2",
+        "@nx/nx-win32-arm64-msvc": "20.8.2",
+        "@nx/nx-win32-x64-msvc": "20.8.2"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.8.0",
@@ -15560,9 +15606,9 @@
       "license": "MIT"
     },
     "node_modules/parse-path": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.3.tgz",
-      "integrity": "sha512-0R71msgRgmkcZ5CWnzS+GPXJ1Fc+lbKyPDuA83Ej0QKCpf/Feieh813bF38My3CTNBzcQhtRRqvXNpCFF6FRMQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
+      "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15694,13 +15740,26 @@
       "license": "MIT"
     },
     "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-type/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/pathe": {
@@ -16387,19 +16446,6 @@
       "dependencies": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/read-pkg/node_modules/path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
       },
       "engines": {
         "node": ">=4"
@@ -17802,24 +17848,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strong-log-transformer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
-      "integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "duplexer": "^0.1.1",
-        "minimist": "^1.2.0",
-        "through": "^2.3.4"
-      },
-      "bin": {
-        "sl-log-transformer": "bin/sl-log-transformer.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/structured-source": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
@@ -18149,19 +18177,45 @@
       }
     },
     "node_modules/textlint-rule-allowed-uris": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-allowed-uris/-/textlint-rule-allowed-uris-2.0.0.tgz",
-      "integrity": "sha512-KfGajAuDs4fPnujxEi4rNtSds7s4LYg+YWiw5sToY+H/FChYp8XINoRWL6s/evaOAPvjNqmEJaJeVfymRRuNnQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-allowed-uris/-/textlint-rule-allowed-uris-2.0.1.tgz",
+      "integrity": "sha512-X2FXUzn2rrg9Nd1fK11hSkq8LlGrAag3AGybrC9GNKDtO9nqkV23PPZJThqeBWWSekL0bXvh4RpGHnZUw2Faxw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
         "."
       ],
       "dependencies": {
-        "cheerio": "^1.1.2"
+        "parse5": "^8.0.0"
       },
       "peerDependencies": {
         "textlint": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/textlint-rule-allowed-uris/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/textlint-rule-allowed-uris/node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/textlint/node_modules/file-entry-cache": {
@@ -18406,9 +18460,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.4.tgz",
+      "integrity": "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18831,9 +18885,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.12.0.tgz",
-      "integrity": "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.13.0.tgz",
+      "integrity": "sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -19433,9 +19487,9 @@
       }
     },
     "node_modules/vitepress/node_modules/vite": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.6.tgz",
-      "integrity": "sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.1.tgz",
+      "integrity": "sha512-yJ+Mp7OyV+4S+afWo+QyoL9jFWD11QFH0i5i7JypnfTcA1rmgxCbiA8WwAICDEtZ1Z1hzrVhN8R8rGTqkTY8ZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19443,7 +19497,7 @@
         "fdir": "^6.4.6",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
-        "rollup": "^4.40.0",
+        "rollup": "^4.43.0",
         "tinyglobby": "^0.2.14"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "markdownlint-cli": "^0.45.0",
     "prettier": "^3.6.2",
     "prettier-config-bananass": "^0.3.1",
-    "textlint": "^14.7.2",
-    "textlint-rule-allowed-uris": "^2.0.0",
+    "textlint": "14.7.2",
+    "textlint-rule-allowed-uris": "^2.0.1",
     "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
This pull request updates dependencies in the `package.json` file to ensure compatibility and maintain up-to-date tooling.

Dependency updates:

* Upgraded `textlint-rule-allowed-uris` to version `^2.0.1` to include the latest bug fixes and improvements.

Version specification adjustment:

* Changed the version specification for `textlint` from a caret (`^14.7.2`) to an exact version (`14.7.2`) to prevent unintended updates and ensure consistent builds.