### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.6` to `v0.1.0-canary.7` (`prerelease`)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-canary.6"
+  "version": "0.1.0-canary.7"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.6",
+  "version": "0.1.0-canary.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-plugin-mark",
-      "version": "0.1.0-canary.6",
+      "version": "0.1.0-canary.7",
       "workspaces": [
         ".",
         "packages/*",
@@ -20,7 +20,7 @@
         "editorconfig-checker": "^6.1.0",
         "eslint": "^9.32.0",
         "eslint-config-bananass": "^0.3.1",
-        "eslint-plugin-mark": "^0.1.0-canary.6",
+        "eslint-plugin-mark": "^0.1.0-canary.7",
         "husky": "^9.1.5",
         "lerna": "^8.2.2",
         "lint-staged": "^16.1.4",
@@ -19769,7 +19769,7 @@
       }
     },
     "packages/eslint-plugin-mark": {
-      "version": "0.1.0-canary.6",
+      "version": "0.1.0-canary.7",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.1.0",
@@ -19802,18 +19802,18 @@
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.1.0-canary.6",
+      "version": "0.1.0-canary.7",
       "devDependencies": {
-        "eslint-plugin-mark": "^0.1.0-canary.6"
+        "eslint-plugin-mark": "^0.1.0-canary.7"
       }
     },
     "website": {
-      "version": "0.1.0-canary.6",
+      "version": "0.1.0-canary.7",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
         "@shikijs/transformers": "^3.9.1",
         "@shikijs/vitepress-twoslash": "^3.9.2",
-        "eslint-plugin-mark": "^0.1.0-canary.6",
+        "eslint-plugin-mark": "^0.1.0-canary.7",
         "markdown-it-footnote": "^4.0.0",
         "twoslash-eslint": "^0.3.3",
         "vitepress": "^2.0.0-alpha.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.6",
+  "version": "0.1.0-canary.7",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": ">=20.18.0"
@@ -44,7 +44,7 @@
     "editorconfig-checker": "^6.1.0",
     "eslint": "^9.32.0",
     "eslint-config-bananass": "^0.3.1",
-    "eslint-plugin-mark": "^0.1.0-canary.6",
+    "eslint-plugin-mark": "^0.1.0-canary.7",
     "husky": "^9.1.5",
     "lerna": "^8.2.2",
     "lint-staged": "^16.1.4",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mark",
-  "version": "0.1.0-canary.6",
+  "version": "0.1.0-canary.7",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.1.0-canary.6",
+  "version": "0.1.0-canary.7",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "eslint-plugin-mark": "^0.1.0-canary.6"
+    "eslint-plugin-mark": "^0.1.0-canary.7"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "0.1.0-canary.6",
+  "version": "0.1.0-canary.7",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -12,7 +12,7 @@
     "@codecov/vite-plugin": "^1.9.1",
     "@shikijs/transformers": "^3.9.1",
     "@shikijs/vitepress-twoslash": "^3.9.2",
-    "eslint-plugin-mark": "^0.1.0-canary.6",
+    "eslint-plugin-mark": "^0.1.0-canary.7",
     "markdown-it-footnote": "^4.0.0",
     "twoslash-eslint": "^0.3.3",
     "vitepress": "^2.0.0-alpha.9",


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.7`

New release of `lumirlumir/npm-eslint-plugin-mark` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.6` to `v0.1.0-canary.7` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-eslint-plugin-mark/actions/runs/16826671348) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-plugin-mark` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | 9b77b10       |
| Old Version | `v0.1.0-canary.6`  |
| New Version | `v0.1.0-canary.7`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(eslint-plugin-mark): migrate to `parse5` to reduce dependency by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/242
### :hammer_and_wrench: Builds
* build(*): create `cp.mjs` script for file copying and drop `shx` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/151
### :toolbox: Chores
* chore(*): bump `@eslint/markdown` from 6.4.0 to 6.5.0 by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/150
* chore(*): run `npm dedupe` for cleanup by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/152
* chore(sync-server): update `dependabot.yml` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/178
* chore(*): remove `bananass-utils-vitepress` dependency by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/182
* chore(*): move `FUNDING.yml` to `.github` repository by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/192
* chore(sync-server): update `tsconfig.json` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/219
* chore(*): remove `ISSUE_TEMPLATE` in favor of centralized template by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/226
* chore(sync-server): update and cleanup docs in favor of centralized template by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/231
### :memo: Documentation
* docs(*): remove `PULL_REQUEST_TEMPLATE.md` in favor of centralized template by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/203
### :recycle: Code Refactoring
* refactor(eslint-plugin-mark): bump `@eslint/markdown` and update types by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/167
* refactor(*): migrate type declarations to use `@import` syntax by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/173
### :rewind: Reverts
* revert(eslint-plugin-mark): partially revert #134 due to performance regression by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/136
### :arrow_up: Dependency Updates
* chore(deps-dev): bump lint-staged from 16.0.0 to 16.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/137
* chore(deps-dev): bump @types/node from 22.15.21 to 22.15.24 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/139
* chore(deps-dev): bump @types/node from 22.15.24 to 22.15.26 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/140
* chore(deps-dev): bump eslint from 9.27.0 to 9.28.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/141
* chore(deps-dev): bump @types/node from 22.15.26 to 22.15.29 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/142
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.5.5 to 1.6.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/145
* chore(deps-dev): bump @shikijs/transformers from 3.4.2 to 3.6.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/148
* chore(deps-dev): bump textlint-rule-allowed-uris from 1.1.0 to 1.1.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/154
* chore(deps-dev): bump the bananass group across 2 directories with 3 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/153
* chore(deps): bump cheerio from 1.0.0 to 1.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/155
* chore(deps-dev): bump @types/node from 22.15.29 to 24.0.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/158
* chore(deps-dev): bump @shikijs/vitepress-twoslash from 3.4.2 to 3.6.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/161
* chore(deps-dev): bump lint-staged from 16.1.0 to 16.1.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/163
* chore(deps-dev): bump eslint from 9.28.0 to 9.29.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/164
* chore(deps-dev): bump @types/node from 24.0.0 to 24.0.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/166
* chore(deps-dev): bump @shikijs/transformers from 3.6.0 to 3.7.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/168
* chore(deps-dev): bump prettier from 3.5.3 to 3.6.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/172
* chore(deps-dev): bump concurrently from 9.1.2 to 9.2.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/171
* chore(deps-dev): bump @shikijs/vitepress-twoslash from 3.6.0 to 3.7.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/174
* chore(deps-dev): bump prettier from 3.6.0 to 3.6.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/177
* chore(deps-dev): bump eslint from 9.29.0 to 9.30.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/179
* chore(deps-dev): bump @types/node from 24.0.3 to 24.0.7 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/180
* chore(deps-dev): bump prettier from 3.6.1 to 3.6.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/183
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.6.0 to 1.6.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/185
* chore(deps-dev): bump eslint from 9.30.0 to 9.30.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/187
* chore(deps-dev): bump twoslash-eslint from 0.3.1 to 0.3.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/190
* chore(deps-dev): bump @types/node from 24.0.7 to 24.0.10 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/189
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/194
* chore(deps-dev): bump @types/node from 24.0.10 to 24.0.12 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/193
* chore(deps-dev): bump eslint from 9.30.1 to 9.31.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/197
* chore(deps): bump @eslint/markdown from 6.6.0 to 7.0.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/196
* chore(deps-dev): bump @shikijs/vitepress-twoslash from 3.7.0 to 3.8.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/200
* chore(deps-dev): bump @shikijs/transformers from 3.7.0 to 3.8.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/204
* chore(deps): bump @eslint/plugin-kit from 0.3.1 to 0.3.3 in the npm_and_yarn group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/206
* chore(deps): bump cheerio from 1.1.0 to 1.1.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/207
* chore(deps-dev): bump form-data from 4.0.2 to 4.0.4 in the npm_and_yarn group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/209
* chore(deps): bump @eslint/markdown from 7.0.0 to 7.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/210
* chore(deps-dev): bump editorconfig-checker from 6.0.1 to 6.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/214
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/215
* chore(deps-dev): bump @shikijs/vitepress-twoslash from 3.8.0 to 3.8.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/216
* chore(deps-dev): bump `textlint-rule-allowed-uris` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/218
* chore(deps-dev): bump `vitepress` to `alpha` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/220
* chore(deps-dev): bump twoslash-eslint from 0.3.2 to 0.3.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/221
* chore(deps-dev): bump eslint from 9.31.0 to 9.32.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/222
* chore(deps-dev): update eslint requirement from ^9.31.0 to ^9.32.0 in /packages/eslint-plugin-mark by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/223
* chore(deps): update cheerio requirement from ^1.1.1 to ^1.1.2 in /packages/eslint-plugin-mark by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/224
* chore(deps-dev): bump @shikijs/vitepress-twoslash from 3.8.1 to 3.9.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/227
* chore(deps-dev): bump @shikijs/transformers from 3.8.1 to 3.9.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/228
* chore(deps-dev): bump typescript from 5.8.3 to 5.9.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/233
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/232
* chore(deps-dev): bump @types/node from 24.0.12 to 24.2.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/234
* chore(deps-dev): bump @shikijs/vitepress-twoslash from 3.9.1 to 3.9.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/235
* chore(deps-dev): bump lint-staged from 16.1.2 to 16.1.4 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/237
* chore(deps-dev): bump `textlint-rule-allowed-uris` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/241


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-plugin-mark/compare/v0.1.0-canary.6...v0.1.0-canary.7