### PR TITLE
fix(eslint-plugin-mark)!: update ESLint peer dependency version to `^9.15.0`

### DIFF
--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -79,7 +79,7 @@
     "test": "node --test"
   },
   "peerDependencies": {
-    "eslint": "^9.0.0"
+    "eslint": "^9.15.0"
   },
   "dependencies": {
     "@eslint/markdown": "^7.2.0",

--- a/website/docs/get-started/configurations.md
+++ b/website/docs/get-started/configurations.md
@@ -5,7 +5,7 @@
 ::: danger
 
 - This plugin only supports ***ECMAScript Modules (ESM)*** configurations. CommonJS configurations are not supported.
-- This plugin only supports ***ESLint `v9.0.0` and above***.
+- This plugin only supports ***ESLint [`v9.15.0`](https://github.com/eslint/eslint/releases/tag/v9.15.0) and above***.
 
 :::
 

--- a/website/docs/get-started/dependency-versions.md
+++ b/website/docs/get-started/dependency-versions.md
@@ -3,7 +3,7 @@
 ::: info TL;DR
 
 - Module Support: ECMAScript Modules (ESM) only
-- ESLint: `^9.0.0` (Flat Config)
+- ESLint: `^9.15.0` (Flat Config)
 - Node.js: `^18.18.0 || ^20.9.0 || >=21.1.0`
 
 :::
@@ -12,7 +12,7 @@
 
 ## ESLint
 
-The version range of ESLint currently supported is `^9.0.0`.
+The version range of ESLint currently supported is [`^9.15.0`](https://github.com/eslint/eslint/releases/tag/v9.15.0).
 
 ## Node.js
 


### PR DESCRIPTION
This pull request updates the minimum supported version of ESLint for the `eslint-plugin-mark` package and its documentation. The minimum required ESLint version is raised from `9.0.0` to `9.15.0`, and all relevant documentation is updated to reflect this change.

Dependency update:

* Increased the minimum supported ESLint version in `peerDependencies` from `^9.0.0` to `^9.15.0` in `package.json`.

Documentation updates:

* Updated the configuration documentation to specify support for ESLint `v9.15.0` and above, including a link to the release.
* Updated the quick info and dependency version documentation to reflect the new ESLint minimum version. [[1]](diffhunk://#diff-e96558082390e38b1c5e2e3df94bced778e823b82720535a6a7728a4790caf0eL6-R6) [[2]](diffhunk://#diff-e96558082390e38b1c5e2e3df94bced778e823b82720535a6a7728a4790caf0eL15-R15)