### PR TITLE
refactor(eslint-plugin-mark): update rule module typings and imports for consistency

### DIFF
--- a/packages/eslint-plugin-mark/src/core/tests/rule-tester/rule-tester.js
+++ b/packages/eslint-plugin-mark/src/core/tests/rule-tester/rule-tester.js
@@ -12,16 +12,19 @@ import { RuleTester } from 'eslint';
 import markdown from '@eslint/markdown';
 
 // --------------------------------------------------------------------------------
-// Typedefs
+// Typedef
 // --------------------------------------------------------------------------------
 
 /**
- * @import { RuleModule } from "../../types.d.ts";
+ * @import { MarkdownRuleDefinitionTypeOptions } from '@eslint/markdown';
+ * @import { RuleModule } from '../../types.js';
+ * @typedef {MarkdownRuleDefinitionTypeOptions['RuleOptions']} RuleOptions
+ * @typedef {MarkdownRuleDefinitionTypeOptions['MessageIds']} MessageIds
  * @typedef {Parameters<RuleTester['run']>[2]} Tests
  */
 
 // --------------------------------------------------------------------------------
-// Helpers
+// Helper
 // --------------------------------------------------------------------------------
 
 /**
@@ -51,7 +54,7 @@ const ruleTesterGfm = new RuleTester({
 /**
  * Markdown rule tester.
  * @param {string} name Rule name.
- * @param {RuleModule} rule Rule module.
+ * @param {RuleModule<RuleOptions, MessageIds>} rule Rule module.
  * @param {Tests} tests Tests.
  */
 export default function ruleTester(name, rule, tests) {

--- a/packages/eslint-plugin-mark/src/core/types.ts
+++ b/packages/eslint-plugin-mark/src/core/types.ts
@@ -9,7 +9,7 @@
 import type {
   MarkdownRuleDefinition,
   MarkdownRuleDefinitionTypeOptions,
-} from '@eslint/markdown/types';
+} from '@eslint/markdown';
 
 // --------------------------------------------------------------------------------
 // Typedefs
@@ -19,27 +19,26 @@ export type ParserMode = 'commonmark' | 'gfm';
 
 export type RuleContext = Parameters<MarkdownRuleDefinition['create']>[0];
 
-export type RuleModuleTypeOptions = Omit<
-  MarkdownRuleDefinitionTypeOptions,
-  'ExtRuleDocs'
->;
+export type RuleModule<
+  RuleOptions extends MarkdownRuleDefinitionTypeOptions['RuleOptions'],
+  MessageIds extends MarkdownRuleDefinitionTypeOptions['MessageIds'],
+> = MarkdownRuleDefinition<{
+  RuleOptions: RuleOptions;
+  MessageIds: MessageIds;
+  ExtRuleDocs: Partial<{
+    /**
+     * Indicates whether this rule is part of the strict configuration.
+     */
+    strict: boolean;
 
-export type RuleModule<Options extends Partial<RuleModuleTypeOptions> = object> =
-  MarkdownRuleDefinition<
-    Options & {
-      ExtRuleDocs: {
-        /**
-         * Indicates whether this rule is part of the strict configuration.
-         */
-        strict?: boolean | RuleModuleTypeOptions['RuleOptions'];
-        /**
-         * Indicates whether this rule is part of the style configuration.
-         */
-        style?: boolean | RuleModuleTypeOptions['RuleOptions'];
-        /**
-         * Indicates whether this rule is part of the typography configuration.
-         */
-        typography?: boolean | RuleModuleTypeOptions['RuleOptions'];
-      };
-    }
-  >;
+    /**
+     * Indicates whether this rule is part of the style configuration.
+     */
+    style: boolean;
+
+    /**
+     * Indicates whether this rule is part of the typography configuration.
+     */
+    typography: boolean;
+  }>;
+}>;

--- a/packages/eslint-plugin-mark/src/rules/allowed-heading/allowed-heading.js
+++ b/packages/eslint-plugin-mark/src/rules/allowed-heading/allowed-heading.js
@@ -14,10 +14,10 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions; MessageIds: MessageIds }>} RuleModule
- * @typedef {[{h1: headingOption, h2: headingOption, h3: headingOption, h4: headingOption, h5: headingOption, h6: headingOption}]} RuleOptions
+ * @import { RuleModule } from '../../core/types.js';
+ * @typedef {[{ h1: HeadingOption, h2: HeadingOption, h3: HeadingOption, h4: HeadingOption, h5: HeadingOption, h6: HeadingOption }]} RuleOptions
  * @typedef {'allowedHeading' | 'allowedHeadingDepth'} MessageIds
- * @typedef {false | string[]} headingOption
+ * @typedef {false | string[]} HeadingOption
  */
 
 // --------------------------------------------------------------------------------
@@ -30,7 +30,7 @@ const headingRegex = /^#{1,6}\s+/u;
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/alt-text/alt-text.js
+++ b/packages/eslint-plugin-mark/src/rules/alt-text/alt-text.js
@@ -15,7 +15,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[]} RuleOptions
  * @typedef {'altText'} MessageIds
  */
@@ -24,7 +24,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js
+++ b/packages/eslint-plugin-mark/src/rules/code-lang-shorthand/code-lang-shorthand.js
@@ -17,7 +17,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[{ ignores: string[], override: Record<string, string> }]} RuleOptions
  * @typedef {'codeLangShorthand'} MessageIds
  */
@@ -26,7 +26,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // Helpers
 // --------------------------------------------------------------------------------
 
-/** @type {Record<string, string>} */
+/** @satisfies {Record<string, string>} */
 const langShorthandMap = Object.freeze({
   asciidoc: 'adoc',
   batch: 'bat',
@@ -103,7 +103,7 @@ const langShorthandMap = Object.freeze({
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/en-capitalization/en-capitalization.js
+++ b/packages/eslint-plugin-mark/src/rules/en-capitalization/en-capitalization.js
@@ -15,7 +15,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 
 /**
  * @import { Text, Heading, Paragraph } from 'mdast';
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[{ skipHeading: boolean, skipListItem: boolean }]} RuleOptions
  * @typedef {'enCapitalization'} MessageIds
  */
@@ -52,7 +52,7 @@ function findFirstLeafTextNode(node) {
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id/heading-id.js
@@ -15,7 +15,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 
 /**
  * @import { Heading } from 'mdast';
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {['always' | 'never', { leftDelimiter: string, rightDelimiter: string, ignoreDepth: Heading['depth'][] }]} RuleOptions
  * @typedef {'headingIdAlways' | 'headingIdNever'} MessageIds
  */
@@ -24,7 +24,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/image-title/image-title.js
+++ b/packages/eslint-plugin-mark/src/rules/image-title/image-title.js
@@ -19,7 +19,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 
 /**
  * @import { Image, ImageReference, Definition, Html } from 'mdast'
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[]} RuleOptions
  * @typedef {'imageTitle'} MessageIds
  */
@@ -28,7 +28,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/no-bold-paragraph/no-bold-paragraph.js
+++ b/packages/eslint-plugin-mark/src/rules/no-bold-paragraph/no-bold-paragraph.js
@@ -14,7 +14,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[]} RuleOptions
  * @typedef {'noBoldParagraph'} MessageIds
  */
@@ -23,7 +23,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/no-control-character/no-control-character.js
+++ b/packages/eslint-plugin-mark/src/rules/no-control-character/no-control-character.js
@@ -3,8 +3,6 @@
  * @author 루밀LuMir(lumirlumir)
  */
 
-/* eslint-disable no-control-regex -- Needed for rule definition. */
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------
@@ -18,7 +16,7 @@ import { URL_RULE_DOCS, ZERO_TO_ONE_BASED_OFFSET } from '../../core/constants.js
 
 /**
  * @import { Position } from 'unist';
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[{ skipCode: boolean, skipInlineCode: boolean }]} RuleOptions
  * @typedef {'noControlCharacter'} MessageIds
  */
@@ -27,14 +25,14 @@ import { URL_RULE_DOCS, ZERO_TO_ONE_BASED_OFFSET } from '../../core/constants.js
 // Helpers
 // --------------------------------------------------------------------------------
 
-const controlCharacterRegex =
+const controlCharacterRegex = // eslint-disable-next-line no-control-regex -- Needed for rule definition.
   /[\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u000b\u000c\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008a\u008b\u008c\u008d\u008e\u008f\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f\u202c\u202d\u202e]/gu;
 
 // --------------------------------------------------------------------------------
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/no-curly-quote/no-curly-quote.js
+++ b/packages/eslint-plugin-mark/src/rules/no-curly-quote/no-curly-quote.js
@@ -15,7 +15,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[{ leftDoubleQuotationMark: boolean, rightDoubleQuotationMark: boolean, leftSingleQuotationMark: boolean, rightSingleQuotationMark: boolean }]} RuleOptions
  * @typedef {'noCurlyQuote'} MessageIds
  */
@@ -35,7 +35,7 @@ const singleQuotationMark = "'";
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/no-double-space/no-double-space.js
+++ b/packages/eslint-plugin-mark/src/rules/no-double-space/no-double-space.js
@@ -15,7 +15,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[{ multipleSpace: boolean }]} RuleOptions
  * @typedef {'noDoubleSpace' | 'noMultipleSpace'} MessageIds
  */
@@ -33,7 +33,7 @@ const singleSpace = ' ';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/no-emoji/no-emoji.js
+++ b/packages/eslint-plugin-mark/src/rules/no-emoji/no-emoji.js
@@ -17,7 +17,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[]} RuleOptions
  * @typedef {'noEmoji'} MessageIds
  */
@@ -26,7 +26,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/no-git-conflict-marker/no-git-conflict-marker.js
+++ b/packages/eslint-plugin-mark/src/rules/no-git-conflict-marker/no-git-conflict-marker.js
@@ -16,7 +16,7 @@ import { URL_RULE_DOCS, ZERO_TO_ONE_BASED_OFFSET } from '../../core/constants.js
 
 /**
  * @import { Position } from 'unist';
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[{ skipCode: boolean }]} RuleOptions
  * @typedef {'noGitConflictMarker'} MessageIds
  */
@@ -31,7 +31,7 @@ const gitConflictMarkerRegex = /^(?:<{7}(?!<)|={7}(?!=)|>{7}(?!>))/gmu;
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/no-irregular-dash/no-irregular-dash.js
+++ b/packages/eslint-plugin-mark/src/rules/no-irregular-dash/no-irregular-dash.js
@@ -16,7 +16,7 @@ import { URL_RULE_DOCS, ZERO_TO_ONE_BASED_OFFSET } from '../../core/constants.js
 
 /**
  * @import { Position } from 'unist';
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[{ skipCode: boolean, skipInlineCode: boolean }]} RuleOptions
  * @typedef {'noIrregularDash'} MessageIds
  */
@@ -32,7 +32,7 @@ const irregularDashRegex =
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/no-irregular-whitespace/no-irregular-whitespace.js
+++ b/packages/eslint-plugin-mark/src/rules/no-irregular-whitespace/no-irregular-whitespace.js
@@ -16,7 +16,7 @@ import { URL_RULE_DOCS, ZERO_TO_ONE_BASED_OFFSET } from '../../core/constants.js
 
 /**
  * @import { Position } from 'unist';
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[{ skipCode: boolean, skipInlineCode: boolean }]} RuleOptions
  * @typedef {'noIrregularWhitespace'} MessageIds
  */
@@ -32,7 +32,7 @@ const irregularWhitespaceRegex =
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-mark/src/rules/no-unused-definition/no-unused-definition.js
+++ b/packages/eslint-plugin-mark/src/rules/no-unused-definition/no-unused-definition.js
@@ -17,7 +17,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import("../../core/types.js").RuleModule<{ RuleOptions: RuleOptions, MessageIds: MessageIds }>} RuleModule
+ * @import { RuleModule } from '../../core/types.js';
  * @typedef {[]} RuleOptions
  * @typedef {'noUnusedDefinition'} MessageIds
  */
@@ -26,7 +26,7 @@ import { URL_RULE_DOCS } from '../../core/constants.js';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-/** @type {RuleModule} */
+/** @type {RuleModule<RuleOptions, MessageIds>} */
 export default {
   meta: {
     type: 'problem',


### PR DESCRIPTION
This pull request refactors the typing and usage of the `RuleModule` type throughout the ESLint plugin for Markdown. The main goal is to standardize type definitions, improve type safety, and simplify how rule modules declare their options and message IDs. The changes also update import paths and remove redundant type aliases. Below are the most important changes grouped by theme.

### Type System Improvements

* Refactored the `RuleModule` type in `core/types.ts` to use generic parameters for `RuleOptions` and `MessageIds`, replacing the previous approach that relied on partial type options and custom extensions. This change improves type safety and clarity for rule authors.
* Updated all rule files to use the new generic `RuleModule<RuleOptions, MessageIds>` type, removing older typedefs and ensuring that rule definitions are properly typed. [[1]](diffhunk://#diff-d5951c4773cae305a950c0c4cc9ccb7ae0edd097899fe6b6a095e19a15c7f34fL17-R20) [[2]](diffhunk://#diff-6560944db191e902d3ac04b45b164f66c5bd84703cfc914c50c75fc942048c9fL18-R18) [[3]](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bL20-R20) [[4]](diffhunk://#diff-c7bb138240c9515f2c61e36fd888c71d2b70925c4e404862f67776dc125c8e0dL18-R18) [[5]](diffhunk://#diff-64161e7614a45746324c8428c938fb2c11f1cf8d9f91d58b096a51ee7e13fb10L18-R18) [[6]](diffhunk://#diff-d8ba748806ee139927f1d01c6a50e08e3e11fbd5e641eb0d9341b176862176faL22-R22) [[7]](diffhunk://#diff-142341221567262737addbdd1ec0463dd2bd78ea8c050e86302251a583a2c3b4L17-R17) [[8]](diffhunk://#diff-8d03766e703fb2471ad6f5b6f07dbd94c44a73aba484ea6e1c747217ef9ac7ceL21-R19) [[9]](diffhunk://#diff-f07d349d38a9d669eeaf3c2a3d369b95cd858048da1d815e4fcc0cf495525ba0L18-R18) [[10]](diffhunk://#diff-279d5c20e3f61c9862ba798b78492df0a43e70bc5d724cc593f914c8b1037c3fL18-R18) [[11]](diffhunk://#diff-707b0f8455353358a18744406669218fbd523185bad4689adc052940f41a8308L20-R20) [[12]](diffhunk://#diff-71e4539072887e4bbfb0111ba765573a68249bbb8cd92e49722db3e829f9485bL19-R19)

### Rule Definition Consistency

* Updated all rule exports to explicitly specify their type as `RuleModule<RuleOptions, MessageIds>`, ensuring consistency and type safety across rule implementations. [[1]](diffhunk://#diff-d5951c4773cae305a950c0c4cc9ccb7ae0edd097899fe6b6a095e19a15c7f34fL33-R33) [[2]](diffhunk://#diff-6560944db191e902d3ac04b45b164f66c5bd84703cfc914c50c75fc942048c9fL27-R27) [[3]](diffhunk://#diff-6502c3e17c3ed74bdc42a42b44982988f8ec9f559d0a5d0afbeec6f7ece1e41bL106-R106) [[4]](diffhunk://#diff-c7bb138240c9515f2c61e36fd888c71d2b70925c4e404862f67776dc125c8e0dL55-R55) [[5]](diffhunk://#diff-64161e7614a45746324c8428c938fb2c11f1cf8d9f91d58b096a51ee7e13fb10L27-R27) [[6]](diffhunk://#diff-d8ba748806ee139927f1d01c6a50e08e3e11fbd5e641eb0d9341b176862176faL31-R31) [[7]](diffhunk://#diff-142341221567262737addbdd1ec0463dd2bd78ea8c050e86302251a583a2c3b4L26-R26) [[8]](diffhunk://#diff-8d03766e703fb2471ad6f5b6f07dbd94c44a73aba484ea6e1c747217ef9ac7ceL30-R35) [[9]](diffhunk://#diff-f07d349d38a9d669eeaf3c2a3d369b95cd858048da1d815e4fcc0cf495525ba0L38-R38) [[10]](diffhunk://#diff-279d5c20e3f61c9862ba798b78492df0a43e70bc5d724cc593f914c8b1037c3fL36-R36) [[11]](diffhunk://#diff-707b0f8455353358a18744406669218fbd523185bad4689adc052940f41a8308L29-R29) [[12]](diffhunk://#diff-71e4539072887e4bbfb0111ba765573a68249bbb8cd92e49722db3e829f9485bL34-R34)

### Import Path and Typedef Updates

* Updated import paths for type definitions to use direct imports from `@eslint/markdown` instead of deep paths, and removed redundant type aliases in `core/types.ts`.
* Standardized JSDoc comments and typedefs in rule files to use the new type definitions, improving documentation and maintainability.

### Minor Code Quality Improvements

* Used `@satisfies` for type assertion in the code lang shorthand rule to improve type safety and readability.
* Moved the `eslint-disable no-control-regex` directive inline with the regex definition for better context and code cleanliness in the no-control-character rule. [[1]](diffhunk://#diff-8d03766e703fb2471ad6f5b6f07dbd94c44a73aba484ea6e1c747217ef9ac7ceL6-L7) [[2]](diffhunk://#diff-8d03766e703fb2471ad6f5b6f07dbd94c44a73aba484ea6e1c747217ef9ac7ceL30-R35)

### Rule Tester Updates

* Updated the `ruleTester` helper to use the new generic `RuleModule<RuleOptions, MessageIds>` type, ensuring that rule tests are properly typed and validated.

Let me know if you have questions about any specific change or want to see how these updates affect rule implementation or testing!