### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.7` to `v0.1.0-canary.8` (`prerelease`)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-canary.7"
+  "version": "0.1.0-canary.8"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.7",
+  "version": "0.1.0-canary.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-plugin-mark",
-      "version": "0.1.0-canary.7",
+      "version": "0.1.0-canary.8",
       "workspaces": [
         ".",
         "packages/*",
@@ -20,7 +20,7 @@
         "editorconfig-checker": "^6.1.0",
         "eslint": "^9.37.0",
         "eslint-config-bananass": "^0.4.1",
-        "eslint-plugin-mark": "^0.1.0-canary.7",
+        "eslint-plugin-mark": "^0.1.0-canary.8",
         "husky": "^9.1.7",
         "lerna": "^8.2.3",
         "lint-staged": "^16.2.3",
@@ -19815,7 +19815,7 @@
       }
     },
     "packages/eslint-plugin-mark": {
-      "version": "0.1.0-canary.7",
+      "version": "0.1.0-canary.8",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.3.0",
@@ -19842,18 +19842,18 @@
     },
     "tests/integration": {
       "name": "tests-integration",
-      "version": "0.1.0-canary.7",
+      "version": "0.1.0-canary.8",
       "devDependencies": {
-        "eslint-plugin-mark": "^0.1.0-canary.7"
+        "eslint-plugin-mark": "^0.1.0-canary.8"
       }
     },
     "website": {
-      "version": "0.1.0-canary.7",
+      "version": "0.1.0-canary.8",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
         "@shikijs/transformers": "^3.12.3",
         "@shikijs/vitepress-twoslash": "^3.13.0",
-        "eslint-plugin-mark": "^0.1.0-canary.7",
+        "eslint-plugin-mark": "^0.1.0-canary.8",
         "markdown-it-footnote": "^4.0.0",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "^2.0.0-alpha.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.7",
+  "version": "0.1.0-canary.8",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": ">=20.19.4"
@@ -44,7 +44,7 @@
     "editorconfig-checker": "^6.1.0",
     "eslint": "^9.37.0",
     "eslint-config-bananass": "^0.4.1",
-    "eslint-plugin-mark": "^0.1.0-canary.7",
+    "eslint-plugin-mark": "^0.1.0-canary.8",
     "husky": "^9.1.7",
     "lerna": "^8.2.3",
     "lint-staged": "^16.2.3",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mark",
-  "version": "0.1.0-canary.7",
+  "version": "0.1.0-canary.8",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "tests-integration",
-  "version": "0.1.0-canary.7",
+  "version": "0.1.0-canary.8",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "devDependencies": {
-    "eslint-plugin-mark": "^0.1.0-canary.7"
+    "eslint-plugin-mark": "^0.1.0-canary.8"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "0.1.0-canary.7",
+  "version": "0.1.0-canary.8",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",
@@ -12,7 +12,7 @@
     "@codecov/vite-plugin": "^1.9.1",
     "@shikijs/transformers": "^3.12.3",
     "@shikijs/vitepress-twoslash": "^3.13.0",
-    "eslint-plugin-mark": "^0.1.0-canary.7",
+    "eslint-plugin-mark": "^0.1.0-canary.8",
     "markdown-it-footnote": "^4.0.0",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "^2.0.0-alpha.12",


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.8`

New release of `lumirlumir/npm-eslint-plugin-mark` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.7` to `v0.1.0-canary.8` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-eslint-plugin-mark/actions/runs/18270284727) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-plugin-mark` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | 8974a58       |
| Old Version | `v0.1.0-canary.7`  |
| New Version | `v0.1.0-canary.8`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* fix(eslint-plugin-mark)!: update ESLint peer dependency version to `^9.15.0` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/293
* fix(eslint-plugin-mark)!: rename `allowed` to `allow` across rules by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/315
### :toolbox: Chores
* chore(*): bump `.nvmrc` to 20.19.4 from 20.18.0 by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/247
* chore(eslint-plugin-mark): replace `no-dead-url` with `no-url-trailing-slash` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/250
* chore(sync-server): bump GitHub Actions version by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/256
* chore(*): bump dependencies by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/265
* chore(sync-server): bump GitHub Actions versions by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/287
* chore(*): update root level node engine requirement to `>=20.19.4` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/292
* chore(*): update `dependabot` and `vscode/settings` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/303
* chore(*): bump dependencies by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/304
* chore(sync-server): update `sync-client.yml` and `tsconfig.json` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/294
* chore(*): remove `cooldown` in dependabot (buggy) by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/308
### :recycle: Code Refactoring
* refactor(eslint-plugin-mark): rename `types.d.ts` to `types.ts` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/273
* refactor(eslint-plugin-mark): update rule module typings and imports for consistency by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/305
* refactor(eslint-plugin-mark): update type annotations to use `@satisfies` in `constants` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/311
### :arrow_up: Dependency Updates
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.6.1 to 1.6.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/249
* chore(deps-dev): bump lint-staged from 16.1.4 to 16.1.5 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/244
* chore(deps-dev): bump twoslash-eslint from 0.3.3 to 0.3.4 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/254
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/253
* chore(deps-dev): bump @types/node from 24.2.0 to 24.3.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/257
* chore(deps-dev): bump @shikijs/transformers from 3.9.1 to 3.11.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/258
* chore(deps-dev): bump eslint from 9.33.0 to 9.34.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/267
* chore(deps-dev): bump concurrently from 9.2.0 to 9.2.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/268
* chore(deps-dev): bump @shikijs/transformers from 3.11.0 to 3.12.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/270
* chore(deps-dev): bump @shikijs/vitepress-twoslash from 3.9.2 to 3.12.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/269
* chore(deps): bump emoji-regex from 10.4.0 to 10.5.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/274
* chore(deps-dev): bump @shikijs/transformers from 3.12.0 to 3.12.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/276
* chore(deps-dev): bump @shikijs/transformers from 3.12.1 to 3.12.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/280
* chore(deps-dev): bump @shikijs/vitepress-twoslash from 3.12.0 to 3.12.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/283
* chore(deps): bump the npm_and_yarn group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/288
* chore(deps-dev): bump lint-staged from 16.1.5 to 16.1.6 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/282
* chore(deps-dev): bump @types/node from 24.3.0 to 24.3.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/289
* chore(deps-dev): bump eslint from 9.34.0 to 9.35.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/290
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/296
* chore(deps-dev): bump @types/node from 24.3.1 to 24.5.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/299
* chore(deps-dev): bump @shikijs/vitepress-twoslash from 3.12.2 to 3.13.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/300
* chore(deps-dev): bump @shikijs/transformers from 3.12.2 to 3.12.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/306
* chore(deps-dev): bump lint-staged from 16.1.6 to 16.2.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/309
* chore(deps-dev): bump @types/node from 24.5.2 to 24.6.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/310
* chore(deps-dev): bump typescript from 5.9.2 to 5.9.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/312
* chore(deps-dev): bump @types/node from 24.6.0 to 24.6.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/313
* chore(deps-dev): bump @types/node from 24.6.1 to 24.6.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/314
* chore(deps-dev): bump eslint from 9.36.0 to 9.37.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/316


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-plugin-mark/compare/v0.1.0-canary.7...v0.1.0-canary.8